### PR TITLE
Fix build with current snapd-glib version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,7 @@ parts:
       - -Dvala-bindings=false
       - -Dqt-bindings=false
       - -Dqml-bindings=false
+      - -Dsoup2=true
     organize:
       snap/snapd-desktop-integration/current/usr: usr
     build-packages:


### PR DESCRIPTION
The current versions of snapd-glib use, by default, libsoup3, which isn't available in Core20/Gnome-3-38. This fact breaks building of this snap.

This patch fixes this by forcing snapd-glib to use libsoup2.