### PR TITLE
Don't restart if DISPLAY is not set

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ apps:
     daemon: simple
     passthrough: #///! TODO: Remove once daemon-scope lands in snapcraft
       daemon-scope: user
-    restart-condition: always
+    restart-condition: on-failure
     plugs:
       - snap-themes-control
 

--- a/src/main.c
+++ b/src/main.c
@@ -233,10 +233,11 @@ main(int argc, char **argv)
 {
     setlocale(LC_ALL, "");
     bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
-    g_print("Localedir: %s\n", LOCALEDIR);
     textdomain (GETTEXT_PACKAGE);
 
-    gtk_init(&argc, &argv);
+    if (!gtk_init_check(&argc, &argv)) {
+        return 0;
+    }
     notify_init("snapd-desktop-integration");
 
     g_autoptr(GOptionContext) context = g_option_context_new ("- snapd desktop integration daemon");


### PR DESCRIPTION
In some cases, like when connecting from a remote terminal using SSH, GTK can't be initialized and fails. In that case, this daemon keeps being relaunched over and over.

This patch fixes it by checking first if it is possible to initialize GTK, and only relaunching the daemon if there was an error.

Fix https://github.com/snapcore/snapd-desktop-integration/issues/14