### PR TITLE
DT-576: don't duplicate refresh popups

### DIFF
--- a/src/ds_state.h
+++ b/src/ds_state.h
@@ -25,6 +25,9 @@ typedef struct {
     /* The desktop notifications */
     NotifyNotification *install_notification;
     NotifyNotification *progress_notification;
+
+    /* The list of current refresh popups */
+    GList *refreshing_list;
 } DsState;
 
 #endif // __DS_STATE_H__

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,7 @@
 
 #include "ds_state.h"
 #include "dbus.h"
+#include "refresh_status.h"
 
 /* Number of second to wait after a theme change before checking for installed snaps. */
 #define CHECK_THEME_TIMEOUT_SECONDS 1
@@ -20,6 +21,7 @@ ds_state_free(DsState *state)
     g_clear_pointer(&state->sound_theme_name, g_free);
     g_clear_object(&state->install_notification);
     g_clear_object(&state->progress_notification);
+    g_list_free_full(state->refreshing_list, (GDestroyNotify)refresh_state_free);
     g_free(state);
 }
 

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -49,6 +49,13 @@ handle_application_is_being_refreshed(GVariant *parameters,
     GString *labelText;
 
     g_variant_get(parameters, "(&s&sa{sv})", &appName, &lockFilePath, &extraParams);
+
+    for (GList *list = ds_state->refreshing_list; list != NULL; list=list->next) {
+        state = (RefreshState *)list->data;
+        if (0 == g_strcmp0(state->appName->str, appName)) {
+            return;
+        }
+    }
     state = refresh_state_new(ds_state, appName);
     state->lockFile = g_strdup(lockFilePath);
     state->window = GTK_WINDOW(g_object_ref_sink(gtk_window_new(GTK_WINDOW_TOPLEVEL)));
@@ -73,6 +80,7 @@ handle_application_is_being_refreshed(GVariant *parameters,
     state->timeoutId = g_timeout_add(200, G_SOURCE_FUNC(refresh_progress_bar), state);
     state->closeId = g_signal_connect(G_OBJECT(state->window), "delete-event", G_CALLBACK(delete_window), state);
     gtk_widget_show_all(GTK_WIDGET(state->window));
+    ds_state->refreshing_list = g_list_append(ds_state->refreshing_list, state);
 }
 
 RefreshState *
@@ -86,6 +94,11 @@ refresh_state_new(DsState *state,
 }
 
 void refresh_state_free(RefreshState *state) {
+
+    DsState *dsstate = state->dsstate;
+
+    dsstate->refreshing_list = g_list_remove(dsstate->refreshing_list, state);
+
     if (state->timeoutId != 0) {
         g_source_remove(state->timeoutId);
     }


### PR DESCRIPTION
This MR keeps track of the snaps that have a refresh popup, to avoid showing more than one.