### PR TITLE
DT-719: Migrate into GtkApplication

### DIFF
--- a/src/dbus.h
+++ b/src/dbus.h
@@ -20,10 +20,9 @@
 
 #include "ds_state.h"
 
-
-void
+gboolean
 register_dbus (GDBusConnection  *connection,
-               const char       *name,
-               DsState          *state);
+               DsState          *state,
+               GError          **error);
 
 #endif //__DBUS_H__

--- a/src/ds_state.h
+++ b/src/ds_state.h
@@ -25,6 +25,7 @@
 typedef struct {
     GtkSettings *settings;
     SnapdClient *client;
+    GtkApplication *app;
 
     /* Timer to delay checking after theme changes */
     guint check_delay_timer_id;

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -89,7 +89,7 @@ handle_application_is_being_refreshed(GVariant *parameters,
     } else {
         state->lockFile = g_strdup(lockFilePath);
     }
-    state->window = GTK_WINDOW(g_object_ref_sink(gtk_window_new(GTK_WINDOW_TOPLEVEL)));
+    state->window = GTK_APPLICATION_WINDOW(g_object_ref_sink(gtk_application_window_new(ds_state->app)));
 
     container = g_object_ref_sink(gtk_box_new(GTK_ORIENTATION_VERTICAL, 30));
     gtk_container_add(GTK_CONTAINER(state->window), container);
@@ -145,7 +145,6 @@ refresh_state_new(DsState *state,
 void refresh_state_free(RefreshState *state) {
 
     DsState *dsstate = state->dsstate;
-
     dsstate->refreshing_list = g_list_remove(dsstate->refreshing_list, state);
 
     if (state->timeoutId != 0) {

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -145,6 +145,7 @@ refresh_state_new(DsState *state,
 void refresh_state_free(RefreshState *state) {
 
     DsState *dsstate = state->dsstate;
+
     dsstate->refreshing_list = g_list_remove(dsstate->refreshing_list, state);
 
     if (state->timeoutId != 0) {

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -39,7 +39,6 @@ void handle_close_application_window(GVariant *parameters,
 RefreshState *refresh_state_new(DsState *state,
                                 gchar *appName);
 
-void remove_from_list_and_destroy(RefreshState *state);
 void refresh_state_free(RefreshState *state);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RefreshState, refresh_state_free);

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -25,7 +25,7 @@
 typedef struct {
     DsState              *dsstate;
     GString              *appName;
-    GtkWindow *window;
+    GtkApplicationWindow *window;
     GtkWidget            *progressBar;
     gchar                *lockFile;
     guint                 timeoutId;
@@ -39,6 +39,7 @@ void handle_close_application_window(GVariant *parameters,
 RefreshState *refresh_state_new(DsState *state,
                                 gchar *appName);
 
+void remove_from_list_and_destroy(RefreshState *state);
 void refresh_state_free(RefreshState *state);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(RefreshState, refresh_state_free);


### PR DESCRIPTION
Currently, snapd-desktop-integration uses an odd mix of glib mainloop and pieces of GTK. This must be updated to use GtkApplication, in order to do a future full migration into Gtk4.