### PR TITLE
Fix timer bug

### DIFF
--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -6,23 +6,12 @@
 
 #include <libintl.h>
 
-
-static gboolean
-destroy_state_at_idle(RefreshState *state) {
-    refresh_state_free(state);
-    return G_SOURCE_REMOVE;
-}
-
 static gboolean
 delete_window(GtkWindow    *self,
               GdkEvent     *event,
               RefreshState *state)
 {
-    if (state->timeoutId != 0) {
-        g_source_remove(state->timeoutId);
-        state->timeoutId = 0;
-    }
-    g_idle_add(G_SOURCE_FUNC(destroy_state_at_idle), state);
+    refresh_state_free (state);
     return TRUE;
 }
 
@@ -32,14 +21,12 @@ refresh_progress_bar(RefreshState *state) {
     gtk_progress_bar_pulse(GTK_PROGRESS_BAR(state->progressBar));
     if (stat(state->lockFile, &statbuf) != 0) {
         if ((errno == ENOENT) || (errno == ENOTDIR)) {
-            state->timeoutId = 0;
-            g_idle_add(G_SOURCE_FUNC(destroy_state_at_idle), state);
+            refresh_state_free (state);
             return G_SOURCE_REMOVE;
         }
     } else {
         if (statbuf.st_size == 0) {
-            state->timeoutId = 0;
-            g_idle_add(G_SOURCE_FUNC(destroy_state_at_idle), state);
+            refresh_state_free (state);
             return G_SOURCE_REMOVE;
         }
     }

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -18,6 +18,10 @@ delete_window(GtkWindow    *self,
               GdkEvent     *event,
               RefreshState *state)
 {
+    if (state->timeoutId != 0) {
+        g_source_remove(state->timeoutId);
+        state->timeoutId = 0;
+    }
     g_idle_add(G_SOURCE_FUNC(destroy_state_at_idle), state);
     return TRUE;
 }

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -28,11 +28,15 @@ refresh_progress_bar(RefreshState *state) {
     gtk_progress_bar_pulse(GTK_PROGRESS_BAR(state->progressBar));
     if (stat(state->lockFile, &statbuf) != 0) {
         if ((errno == ENOENT) || (errno == ENOTDIR)) {
+            state->timeoutId = 0;
             g_idle_add(G_SOURCE_FUNC(destroy_state_at_idle), state);
+            return G_SOURCE_REMOVE;
         }
     } else {
         if (statbuf.st_size == 0) {
+            state->timeoutId = 0;
             g_idle_add(G_SOURCE_FUNC(destroy_state_at_idle), state);
+            return G_SOURCE_REMOVE;
         }
     }
     return G_SOURCE_CONTINUE;


### PR DESCRIPTION
When the timer checks the file content and decides to destroy the window, it can happens that the timer function can be called twice before the window is really destroyed. This can result in a double-free bug.

To avoid that, this MR removes the timer callback in that case.