### PR TITLE
DT-774: install required theme snap on notification click

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -82,7 +82,7 @@ static void
 notify_cb(NotifyNotification *notification, char *action, gpointer user_data) {
     DsState *state = user_data;
 
-    if (strcmp(action, "yes") == 0) {
+    if ((strcmp(action, "yes") == 0) || (strcmp(action, "default") == 0)) {
         g_print("Installing missing theme snaps...\n");
         state->progress_notification = notify_notification_new(
             _("Installing missing theme snaps:"),
@@ -129,21 +129,22 @@ show_install_notification (DsState *state)
         "dialog-question");
     g_signal_connect(state->install_notification, "closed",
                      G_CALLBACK(notification_closed_cb), state);
-    notify_notification_set_timeout(state->install_notification, 0);
+    notify_notification_set_timeout(state->install_notification, NOTIFY_EXPIRES_NEVER);
     notify_notification_add_action(state->install_notification,
         "yes",
-        /// TRANSLATORS: answer to the question "Would you like to install them now?"
+        /// TRANSLATORS: answer to the question "Would you like to install them now?" referred to snap themes
         _("Yes"),
         notify_cb,
         state,
         NULL);
     notify_notification_add_action(state->install_notification,
         "no",
-        /// TRANSLATORS: answer to the question "Would you like to install them now?"
+        /// TRANSLATORS: answer to the question "Would you like to install them now?" referred to snap themes
         _("No"),
         notify_cb,
         state,
         NULL);
+    notify_notification_add_action(state->install_notification, "default", "default", notify_cb, state, NULL);
 
     notify_notification_show(state->install_notification, NULL);
 }


### PR DESCRIPTION
When a gtk-theme snap is missing, snapd-desktop-integration shows a notification allowing to install it. Unfortunately, when that notification is moved to the list of "old" notifications, it stops reacting.

The reason is that when a notification in that list is clicked, the program that created it receives a 'default' action, while the two actions defined in the notification are 'yes' and 'no'.

This patch adds a 'default' action that also installs the snap.

Fix https://github.com/snapcore/snapd-desktop-integration/issues/13