### PR TITLE
DT-775: show a meaningful message on error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -61,10 +61,20 @@ install_themes_cb(GObject *object, GAsyncResult *result, gpointer user_data)
         _("Complete."), "dialog-information");
     } else {
         g_print("Installation failed: %s\n", error->message);
+        gchar *error_message;
+        switch (error->code) {
+        case SNAPD_ERROR_AUTH_CANCELLED:
+            /// TRANSLATORS: installing a missing theme snap was cancelled by the user
+            error_message = _("Canceled by the user.");
+            break;
+        default:
+            /// TRANSLATORS: installing a missing theme snap failed
+            error_message = _("Failed.");
+            break;
+        }
         notify_notification_update(state->progress_notification,
         _("Installing missing theme snaps:"),
-        /// TRANSLATORS: trying to install a missing theme snap failed
-        _("Failed."),
+        error_message,
         "dialog-information");
     }
 


### PR DESCRIPTION
If a gtk-theme snap is missing and snapd-desktop-integration offers the user to install it, the user clicks on "yes" and then it cancels the process (for example, when asked by the root password), the error message is meaninless: it just says "failed".

This patch fixes this, and puts the basic infraestructure to show more specific errors on other cases.

Fix https://github.com/snapcore/snapd-desktop-integration/issues/13