### PR TITLE
DT-880: fix "spam" in journalctl

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ apps:
     daemon: simple
     passthrough: #///! TODO: Remove once daemon-scope lands in snapcraft
       daemon-scope: user
-    restart-condition: always
+    restart-condition: on-success
     restart-delay: 2s
     plugs:
       - snap-themes-control

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,10 @@
 #include <locale.h>
 #include <libintl.h>
 #include "config.h"
+#include <unistd.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <signal.h>
 
 #include "ds_state.h"
 #include "dbus.h"
@@ -340,14 +344,48 @@ do_shutdown (GObject  *object,
     notify_uninit();
 }
 
+static int global_retval = 0;
+
+void
+sighandler(int v)
+{
+    global_retval = 128 + v; // exit value is usually 128 + signal_id
+}
+
 int
 main(int argc, char **argv)
 {
+    int retval;
+    int pid = fork();
+    if (pid != 0) {
+        if (pid > 0) {
+            // SIGTERM and SIGINT will be ignored, but
+            // will break WAITPID with a EINTR value in
+            // errno.
+            // This allows the program to always exit with
+            // a NO-ERROR value, and kill the child
+            struct sigaction signal_data;
+            signal_data.sa_handler = sighandler;
+            sigemptyset(&signal_data.sa_mask);
+            signal_data.sa_flags = 0;
+            sigaction(SIGTERM, &signal_data, NULL);
+            sigaction(SIGINT, &signal_data, NULL);
+
+            retval = waitpid(pid, NULL, 0);
+            if ((retval != 0) && (errno == EINTR)) {
+                kill(pid, SIGTERM);
+                waitpid(pid, NULL, 0);
+            }
+        }
+        return global_retval;
+    }
+
     setlocale(LC_ALL, "");
     bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
     textdomain (GETTEXT_PACKAGE);
 
     if (!gtk_init_check(&argc, &argv)) {
+        g_print("Failed to do gtk init\n");
         return 0;
     }
 
@@ -355,12 +393,16 @@ main(int argc, char **argv)
     g_autoptr(DsState) state = g_new0(DsState, 1);
 
     app = gtk_application_new ("io.snapcraft.SnapDesktopIntegration",
-                               G_APPLICATION_FLAGS_NONE);
+                               G_APPLICATION_ALLOW_REPLACEMENT | G_APPLICATION_REPLACE);
     g_signal_connect (G_OBJECT (app), "startup", G_CALLBACK (do_startup), state);
     g_signal_connect (G_OBJECT (app), "shutdown", G_CALLBACK (do_shutdown), state);
     g_signal_connect (G_OBJECT (app), "activate", G_CALLBACK (do_activate), state);
 
     g_application_add_main_option_entries (G_APPLICATION (app), entries);
 
-    return g_application_run (G_APPLICATION (app), argc, argv);
+    g_application_run (G_APPLICATION (app), argc, argv);
+
+    // since it should never ends, if we reach here, we return 0 as error value to
+    // ensure that systemd will relaunch it.
+    return 0;
 }


### PR DESCRIPTION
By default, systemd manages the launch of snapd-desktop-integration. Unfortunately, due to the design of snapd, it is launched as an user-daemon with "wantedby=default.target", which means that it is launched under any session, not only graphical ones. This means that it will fail to run under text-only sessions (like SSH or console sessions), but also in the GDM session (because currently snapd doesn't support launching snaps for users with a HOME folder outside /HOME).

Since the daemon is configured to relaunch in case of a problem, this means that journalctl will be flooded with error messages from the daemon launched in the GDM session (which will be relaunched periodically after the failure).

Unfortunately, just setting the daemon to "don't relaunch" is not an option, for two reasons:

* any bug in the daemon that makes it fail will stop it until the user closes the session and enters again

* the desktop startup is "slow", and the first time that the daemon is launched usually fails to connect to the window manager.

This means that it is mandatory for the daemon to relaunch on failure, if we want to ensure that it is launched during desktop startup; but at the same time we need systemd to avoid relaunching it on failure in the GDM session.

This MR solves this problem by setting the relaunch mode as "on-success". This relaunches the daemon if it returns 0 on exit. This solves the first problem: stop relaunching it on GDM.

To guarantee that the daemon is relaunched always in an user session, it is not enough to add a "return 0;" at the end of the code, because there are several other cases where it can fail. A classic example is a memory access error, that kills the program returning a non-zero value.

To protect the daemon from these cases, the first thing that it does is a "fork();" call to create a child, and it is this child the one that runs the daemon code itself. The parent, in the meantime, just waits until the child dies, and in that moment it returns zero. This way, it doesn't matter what was the return value, systemd will always "see" a zero.

There are some corner cases that must be managed, like what happens when systemd wants to kill the daemon (for example, during shutdown, or when snapd updates the package). For those cases, the parent process captures SIGTERM and SIGINT signals, and if it receives any of them, it kills the child and returns the correct value (128 + signal_id).