### PR TITLE
DT-906: avoid daemon being relaunched over and over

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,12 @@
+gnome = import('gnome')
+
+# The returned source would be passed to another target
+login_src = gnome.gdbus_codegen('org.freedesktop.login1',
+  sources: 'org.freedesktop.login1.dbus.xml',
+  interface_prefix : 'org.freedesktop'
+)
+
+login_session_src = gnome.gdbus_codegen('org.freedesktop.login1.Session',
+  sources: 'org.freedesktop.login1.session.dbus.xml',
+  interface_prefix : 'org.freedesktop.login1.session'
+)

--- a/data/org.freedesktop.login1.dbus.xml
+++ b/data/org.freedesktop.login1.dbus.xml
@@ -1,0 +1,417 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.login1.Manager">
+  <property name="EnableWallMessages" type="b" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </property>
+  <property name="WallMessage" type="s" access="readwrite">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </property>
+  <property name="NAutoVTs" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillOnlyUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillExcludeUsers" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="KillUserProcesses" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RebootParameter" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToFirmwareSetup" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToBootLoaderMenu" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RebootToBootLoaderEntry" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="BootLoaderEntries" type="as" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <property name="BlockInhibited" type="s" access="read">
+  </property>
+  <property name="DelayInhibited" type="s" access="read">
+  </property>
+  <property name="InhibitDelayMaxUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="UserStopDelayUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandlePowerKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandlePowerKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleRebootKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleRebootKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleSuspendKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleSuspendKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleHibernateKey" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleHibernateKeyLongPress" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitch" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitchExternalPower" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HandleLidSwitchDocked" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="HoldoffTimeoutUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleAction" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="IdleActionUSec" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="PreparingForShutdown" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="PreparingForSleep" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="ScheduledShutdown" type="(st)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="Docked" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="LidClosed" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="OnExternalPower" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="RemoveIPC" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimeDirectorySize" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RuntimeDirectoryInodesMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="InhibitorsMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="NCurrentInhibitors" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <property name="SessionsMax" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="NCurrentSessions" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+  </property>
+  <method name="GetSession">
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetSessionByPID">
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetUser">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetUserByPID">
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="GetSeat">
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="o" name="object_path" direction="out"/>
+  </method>
+  <method name="ListSessions">
+   <arg type="a(susso)" name="sessions" direction="out"/>
+  </method>
+  <method name="ListUsers">
+   <arg type="a(uso)" name="users" direction="out"/>
+  </method>
+  <method name="ListSeats">
+   <arg type="a(so)" name="seats" direction="out"/>
+  </method>
+  <method name="ListInhibitors">
+   <arg type="a(ssssuu)" name="inhibitors" direction="out"/>
+  </method>
+  <method name="CreateSession">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="u" name="pid" direction="in"/>
+   <arg type="s" name="service" direction="in"/>
+   <arg type="s" name="type" direction="in"/>
+   <arg type="s" name="class" direction="in"/>
+   <arg type="s" name="desktop" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="u" name="vtnr" direction="in"/>
+   <arg type="s" name="tty" direction="in"/>
+   <arg type="s" name="display" direction="in"/>
+   <arg type="b" name="remote" direction="in"/>
+   <arg type="s" name="remote_user" direction="in"/>
+   <arg type="s" name="remote_host" direction="in"/>
+   <arg type="a(sv)" name="properties" direction="in"/>
+   <arg type="s" name="session_id" direction="out"/>
+   <arg type="o" name="object_path" direction="out"/>
+   <arg type="s" name="runtime_path" direction="out"/>
+   <arg type="h" name="fifo_fd" direction="out"/>
+   <arg type="u" name="uid" direction="out"/>
+   <arg type="s" name="seat_id" direction="out"/>
+   <arg type="u" name="vtnr" direction="out"/>
+   <arg type="b" name="existing" direction="out"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ReleaseSession">
+   <arg type="s" name="session_id" direction="in"/>
+   <annotation name="org.freedesktop.systemd1.Privileged" value="true"/>
+  </method>
+  <method name="ActivateSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="ActivateSessionOnSeat">
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="s" name="seat_id" direction="in"/>
+  </method>
+  <method name="LockSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="UnlockSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="LockSessions">
+  </method>
+  <method name="UnlockSessions">
+  </method>
+  <method name="KillSession">
+   <arg type="s" name="session_id" direction="in"/>
+   <arg type="s" name="who" direction="in"/>
+   <arg type="i" name="signal_number" direction="in"/>
+  </method>
+  <method name="KillUser">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="i" name="signal_number" direction="in"/>
+  </method>
+  <method name="TerminateSession">
+   <arg type="s" name="session_id" direction="in"/>
+  </method>
+  <method name="TerminateUser">
+   <arg type="u" name="uid" direction="in"/>
+  </method>
+  <method name="TerminateSeat">
+   <arg type="s" name="seat_id" direction="in"/>
+  </method>
+  <method name="SetUserLinger">
+   <arg type="u" name="uid" direction="in"/>
+   <arg type="b" name="enable" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="AttachDevice">
+   <arg type="s" name="seat_id" direction="in"/>
+   <arg type="s" name="sysfs_path" direction="in"/>
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="FlushDevices">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="PowerOff">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="PowerOffWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Reboot">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="RebootWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Halt">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HaltWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Suspend">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SuspendWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="Hibernate">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HibernateWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="HybridSleep">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="HybridSleepWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="SuspendThenHibernate">
+   <arg type="b" name="interactive" direction="in"/>
+  </method>
+  <method name="SuspendThenHibernateWithFlags">
+   <arg type="t" name="flags" direction="in"/>
+  </method>
+  <method name="CanPowerOff">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanReboot">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanHalt">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanSuspend">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanHibernate">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanHybridSleep">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="CanSuspendThenHibernate">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="ScheduleShutdown">
+   <arg type="s" name="type" direction="in"/>
+   <arg type="t" name="usec" direction="in"/>
+  </method>
+  <method name="CancelScheduledShutdown">
+   <arg type="b" name="cancelled" direction="out"/>
+  </method>
+  <method name="Inhibit">
+   <arg type="s" name="what" direction="in"/>
+   <arg type="s" name="who" direction="in"/>
+   <arg type="s" name="why" direction="in"/>
+   <arg type="s" name="mode" direction="in"/>
+   <arg type="h" name="pipe_fd" direction="out"/>
+  </method>
+  <method name="CanRebootParameter">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootParameter">
+   <arg type="s" name="parameter" direction="in"/>
+  </method>
+  <method name="CanRebootToFirmwareSetup">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToFirmwareSetup">
+   <arg type="b" name="enable" direction="in"/>
+  </method>
+  <method name="CanRebootToBootLoaderMenu">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToBootLoaderMenu">
+   <arg type="t" name="timeout" direction="in"/>
+  </method>
+  <method name="CanRebootToBootLoaderEntry">
+   <arg type="s" name="result" direction="out"/>
+  </method>
+  <method name="SetRebootToBootLoaderEntry">
+   <arg type="s" name="boot_loader_entry" direction="in"/>
+  </method>
+  <method name="SetWallMessage">
+   <arg type="s" name="wall_message" direction="in"/>
+   <arg type="b" name="enable" direction="in"/>
+  </method>
+  <signal name="SessionNew">
+   <arg type="s" name="session_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="SessionRemoved">
+   <arg type="s" name="session_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="UserNew">
+   <arg type="u" name="uid"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="UserRemoved">
+   <arg type="u" name="uid"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="SeatNew">
+   <arg type="s" name="seat_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="SeatRemoved">
+   <arg type="s" name="seat_id"/>
+   <arg type="o" name="object_path"/>
+  </signal>
+  <signal name="PrepareForShutdown">
+   <arg type="b" name="start"/>
+  </signal>
+  <signal name="PrepareForSleep">
+   <arg type="b" name="start"/>
+  </signal>
+ </interface>
+ <node name="user"/>
+ <node name="session"/>
+ <node name="seat"/>
+</node>

--- a/data/org.freedesktop.login1.session.dbus.xml
+++ b/data/org.freedesktop.login1.session.dbus.xml
@@ -1,0 +1,165 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="Ping"/>
+  <method name="GetMachineId">
+   <arg type="s" name="machine_uuid" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Properties">
+  <method name="Get">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="out" type="v"/>
+  </method>
+  <method name="GetAll">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="props" direction="out" type="a{sv}"/>
+  </method>
+  <method name="Set">
+   <arg name="interface_name" direction="in" type="s"/>
+   <arg name="property_name" direction="in" type="s"/>
+   <arg name="value" direction="in" type="v"/>
+  </method>
+  <signal name="PropertiesChanged">
+   <arg type="s" name="interface_name"/>
+   <arg type="a{sv}" name="changed_properties"/>
+   <arg type="as" name="invalidated_properties"/>
+  </signal>
+ </interface>
+ <interface name="org.freedesktop.login1.Session">
+  <property name="Id" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="User" type="(uo)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Name" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Timestamp" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="TimestampMonotonic" type="t" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="VTNr" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Seat" type="(so)" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="TTY" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Display" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Remote" type="b" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RemoteHost" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="RemoteUser" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Service" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Desktop" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Scope" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Leader" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Audit" type="u" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Type" type="s" access="read">
+  </property>
+  <property name="Class" type="s" access="read">
+   <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="const"/>
+  </property>
+  <property name="Active" type="b" access="read">
+  </property>
+  <property name="State" type="s" access="read">
+  </property>
+  <property name="IdleHint" type="b" access="read">
+  </property>
+  <property name="IdleSinceHint" type="t" access="read">
+  </property>
+  <property name="IdleSinceHintMonotonic" type="t" access="read">
+  </property>
+  <property name="LockedHint" type="b" access="read">
+  </property>
+  <method name="Terminate">
+  </method>
+  <method name="Activate">
+  </method>
+  <method name="Lock">
+  </method>
+  <method name="Unlock">
+  </method>
+  <method name="SetIdleHint">
+   <arg type="b" name="idle" direction="in"/>
+  </method>
+  <method name="SetLockedHint">
+   <arg type="b" name="locked" direction="in"/>
+  </method>
+  <method name="Kill">
+   <arg type="s" name="who" direction="in"/>
+   <arg type="i" name="signal_number" direction="in"/>
+  </method>
+  <method name="TakeControl">
+   <arg type="b" name="force" direction="in"/>
+  </method>
+  <method name="ReleaseControl">
+  </method>
+  <method name="SetType">
+   <arg type="s" name="type" direction="in"/>
+  </method>
+  <method name="TakeDevice">
+   <arg type="u" name="major" direction="in"/>
+   <arg type="u" name="minor" direction="in"/>
+   <arg type="h" name="fd" direction="out"/>
+   <arg type="b" name="inactive" direction="out"/>
+  </method>
+  <method name="ReleaseDevice">
+   <arg type="u" name="major" direction="in"/>
+   <arg type="u" name="minor" direction="in"/>
+  </method>
+  <method name="PauseDeviceComplete">
+   <arg type="u" name="major" direction="in"/>
+   <arg type="u" name="minor" direction="in"/>
+  </method>
+  <method name="SetBrightness">
+   <arg type="s" name="subsystem" direction="in"/>
+   <arg type="s" name="name" direction="in"/>
+   <arg type="u" name="brightness" direction="in"/>
+  </method>
+  <signal name="PauseDevice">
+   <arg type="u" name="major"/>
+   <arg type="u" name="minor"/>
+   <arg type="s" name="type"/>
+  </signal>
+  <signal name="ResumeDevice">
+   <arg type="u" name="major"/>
+   <arg type="u" name="minor"/>
+   <arg type="h" name="fd"/>
+  </signal>
+  <signal name="Lock">
+  </signal>
+  <signal name="Unlock">
+  </signal>
+ </interface>
+</node>

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ json_glib_dep = dependency ('json-glib-1.0')
 
 add_global_arguments('-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()), language:'c')
 
+subdir('data')
 subdir('po')
 subdir('src')
 subdir('tests')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,7 @@ apps:
     restart-delay: 2s
     plugs:
       - snap-themes-control
+      - login-session-observe
 
 slots:
   snapd-desktop-integration:

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,7 +7,7 @@ subdir('resources')
 
 snapd_desktop_integration = executable(
   'snapd-desktop-integration',
-  'main.c', 'refresh_status.c', 'dbus.c', resources,
+  'main.c', 'refresh_status.c', 'dbus.c', resources, login_src, login_session_src,
   dependencies: [gtk_dep, snapd_glib_dep, libnotify_dep],
   install: true,
   link_args: ['-rdynamic'],


### PR DESCRIPTION
When the user enters a non-graphical session (like a SSH session), the GTK initialization in the daemon fails, and it exits with a "zero" error to ensure that systemd relaunches it after two seconds. The result is that, in those cases, the journal log is full of messages saying that snapd-desktop- integration has failed and is being reloaded, one every two seconds.

Also, since the systemd daemons are launched once per user, instead of once per session, we must keep reloading it even if the initialization fails, because it can happen that the user, while having the SSH session opened, enters into a desktop session. Not reloading it would mean that snapd- desktop-integration wouldn't be loaded in that case.

Also, sometimes the daemon is launched "too quickly" by systemd, and although it is a desktop session, the desktop isn't ready and gkt_init_check() fails. In that case we must force a reload to ensure that it is launched again when the desktop is ready.

This patch fixes it by monitoring the logind DBus interface to detect when a new session is opened.

It first calls gtk_init_check(). If it suceeds, then the daemon is running inside a desktop session and it can work as expected.

But if it fails, it can mean that we are inside a SSH session, or in a desktop session but the daemon was launched "too quickly". So in this case, the daemon tries to connect to the login1 daemon, which manages the sessions, and checks all the current sessions for the current user.

If any of the sessions is a graphical session (which is known by its type being "x11", "wayland" or "mir"), then the daemon knows that it must exit in order to be relaunched two seconds after, when the desktop is fully ready.

Instead, if there is no graphical session opened for the current user, the daemon concludes that it is running in a SSH, or in a local, text mode TTY, so it will connect to the "session-new" signal of the logind daemon and wait for new sessions being opened. When that happens, it will check if that new session is a desktop one. If it ins't (because, for example, the user opened another SSH connection), the daemon will just continue waiting for a new session. But if the new session is a desktop one, then it will exit to ensure that systemd will relaunch it.

It is a must to exit and let systemd to relaunch it because the environment variables are different when running in a SSH/TTY session than in a desktop session.

Finally, if the daemon is unable to connect/read data from the logind daemon, it will just exit, thus working like the current code. This can happen if the snap isn't connected to the "login-session-observe" interface.