### PR TITLE
DT-954: add percentage support

### DIFF
--- a/data/io.snapcraft.SnapDesktopIntegration.dbus.xml
+++ b/data/io.snapcraft.SnapDesktopIntegration.dbus.xml
@@ -41,5 +41,28 @@
             <arg direction="in" type="s" name="application_name"/>
             <arg direction="in" type="a{sv}" name="extra_parameters"/>
         </method>
+        <!--"
+             ApplicationRefreshPulsed:"
+             @application_name: the name of the application name"
+             @extra_parameters: a dictionary with extra optional parameters."
+             Method used to notify the daemon that the progress bar must be"
+             set to 'pulsed'."
+        -->"
+        <method name="ApplicationRefreshPulsed">"
+            <arg direction="in" type="s" name="application_name"/>"
+            <arg direction="in" type="a{sv}" name="extra_parameters"/>"
+         </method>"
+        <!--"
+             ApplicationRefreshPercentage:"
+             @application_name: the name of the application name"
+             @percentage: the percent value to set the progress bar (0-100)"
+             @extra_parameters: a dictionary with extra optional parameters."
+             Method used to set the progress bar to an specific value."
+        -->"
+        <method name="ApplicationRefreshPercentage">"
+            <arg direction="in" type="s" name="application_name"/>"
+            <arg direction="in" type="i" name="percentage"/>"
+            <arg direction="in" type="a{sv}" name="extra_parameters"/>"
+        </method>"
     </interface>
 </node>

--- a/data/io.snapcraft.SnapDesktopIntegration.dbus.xml
+++ b/data/io.snapcraft.SnapDesktopIntegration.dbus.xml
@@ -41,28 +41,32 @@
             <arg direction="in" type="s" name="application_name"/>
             <arg direction="in" type="a{sv}" name="extra_parameters"/>
         </method>
-        <!--"
-             ApplicationRefreshPulsed:"
-             @application_name: the name of the application name"
-             @extra_parameters: a dictionary with extra optional parameters."
-             Method used to notify the daemon that the progress bar must be"
-             set to 'pulsed'."
-        -->"
-        <method name="ApplicationRefreshPulsed">"
-            <arg direction="in" type="s" name="application_name"/>"
-            <arg direction="in" type="a{sv}" name="extra_parameters"/>"
-         </method>"
-        <!--"
-             ApplicationRefreshPercentage:"
-             @application_name: the name of the application name"
-             @percentage: the percent value to set the progress bar (0-100)"
-             @extra_parameters: a dictionary with extra optional parameters."
-             Method used to set the progress bar to an specific value."
-        -->"
-        <method name="ApplicationRefreshPercentage">"
-            <arg direction="in" type="s" name="application_name"/>"
-            <arg direction="in" type="i" name="percentage"/>"
-            <arg direction="in" type="a{sv}" name="extra_parameters"/>"
-        </method>"
+        <!--
+             ApplicationRefreshPulsed:
+             @application_name: the name of the application name
+             @bar_text: the text to show over the pulsed bar
+             @extra_parameters: a dictionary with extra optional parameters.
+             Method used to notify the daemon that the progress bar must be
+             set to 'pulsed'.
+        -->
+        <method name="ApplicationRefreshPulsed">
+            <arg direction="in" type="s" name="application_name"/>
+            <arg direction="in" type="s" name="bar_text"/>
+            <arg direction="in" type="a{sv}" name="extra_parameters"/>
+         </method>
+        <!--
+             ApplicationRefreshPercentage:
+             @application_name: the name of the application name
+             @bar_text: the text to show over the pulsed bar (if empty, the percentage will be shown)
+             @percentage: the percent value to set the progress bar (0.0-1.0)
+             @extra_parameters: a dictionary with extra optional parameters.
+             Method used to set the progress bar to an specific value.
+        -->
+        <method name="ApplicationRefreshPercentage">
+            <arg direction="in" type="s" name="application_name"/>
+            <arg direction="in" type="s" name="bar_text"/>
+            <arg direction="in" type="d" name="percentage"/>
+            <arg direction="in" type="a{sv}" name="extra_parameters"/>
+        </method>
     </interface>
 </node>

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -44,6 +44,31 @@ dbus_handle_close_application_window (SnapDesktopIntegration *skeleton,
     return TRUE;
 }
 
+static gboolean
+dbus_handle_set_pulsed_progress (SnapDesktopIntegration *skeleton,
+                                        GDBusMethodInvocation *invocation,
+                                        gchar *snapName,
+                                        GVariantIter *extraParams,
+                                        gpointer data) {
+
+    handle_set_pulsed_progress(snapName, extraParams, data);
+    snap_desktop_integration_complete_application_refresh_pulsed(skeleton, invocation);
+    return TRUE;
+}
+
+static gboolean
+dbus_handle_set_percentage_progress (SnapDesktopIntegration *skeleton,
+                                     GDBusMethodInvocation *invocation,
+                                     gchar *snapName,
+                                     gint percentage,
+                                     GVariantIter *extraParams,
+                                     gpointer data) {
+
+    handle_set_percentage_progress(snapName, percentage, extraParams, data);
+    snap_desktop_integration_complete_application_refresh_percentage(skeleton, invocation);
+    return TRUE;
+}
+
 gboolean
 register_dbus (GDBusConnection  *connection,
                DsState          *state,
@@ -56,6 +81,12 @@ register_dbus (GDBusConnection  *connection,
                      state);
     g_signal_connect(state->skeleton, "handle_application_refresh_completed",
                      G_CALLBACK (dbus_handle_close_application_window),
+                     state);
+    g_signal_connect(state->skeleton, "handle_application_refresh_pulsed",
+                     G_CALLBACK (dbus_handle_set_pulsed_progress),
+                     state);
+    g_signal_connect(state->skeleton, "handle_application_refresh_percentage",
+                     G_CALLBACK (dbus_handle_set_percentage_progress),
                      state);
     return g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON(state->skeleton),
                                              connection,

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -48,10 +48,11 @@ static gboolean
 dbus_handle_set_pulsed_progress (SnapDesktopIntegration *skeleton,
                                  GDBusMethodInvocation *invocation,
                                  gchar *snapName,
+                                 gchar *barText,
                                  GVariantIter *extraParams,
                                  gpointer data) {
 
-    handle_set_pulsed_progress(snapName, extraParams, data);
+    handle_set_pulsed_progress(snapName, barText, extraParams, data);
     snap_desktop_integration_complete_application_refresh_pulsed(skeleton, invocation);
     return TRUE;
 }
@@ -60,11 +61,12 @@ static gboolean
 dbus_handle_set_percentage_progress (SnapDesktopIntegration *skeleton,
                                      GDBusMethodInvocation *invocation,
                                      gchar *snapName,
-                                     gint percentage,
+                                     gchar *barText,
+                                     gdouble percentage,
                                      GVariantIter *extraParams,
                                      gpointer data) {
 
-    handle_set_percentage_progress(snapName, percentage, extraParams, data);
+    handle_set_percentage_progress(snapName, barText, percentage, extraParams, data);
     snap_desktop_integration_complete_application_refresh_percentage(skeleton, invocation);
     return TRUE;
 }

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -46,10 +46,10 @@ dbus_handle_close_application_window (SnapDesktopIntegration *skeleton,
 
 static gboolean
 dbus_handle_set_pulsed_progress (SnapDesktopIntegration *skeleton,
-                                        GDBusMethodInvocation *invocation,
-                                        gchar *snapName,
-                                        GVariantIter *extraParams,
-                                        gpointer data) {
+                                 GDBusMethodInvocation *invocation,
+                                 gchar *snapName,
+                                 GVariantIter *extraParams,
+                                 gpointer data) {
 
     handle_set_pulsed_progress(snapName, extraParams, data);
     snap_desktop_integration_complete_application_refresh_pulsed(skeleton, invocation);

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -147,6 +147,7 @@ handle_set_pulsed_progress(gchar *appName,
         gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), FALSE);
     } else {
         gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
+        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
     }
 }
 

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -132,6 +132,7 @@ handle_close_application_window(gchar *appName,
 
 void
 handle_set_pulsed_progress(gchar *appName,
+                           gchar *barText,
                            GVariantIter *extraParams,
                            DsState  *ds_state)
 {
@@ -142,12 +143,17 @@ handle_set_pulsed_progress(gchar *appName,
         return;
     }
     state->pulsed = TRUE;
-    gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), FALSE);
+    if ((barText == NULL) || (barText[0] == 0)) {
+        gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), FALSE);
+    } else {
+        gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
+    }
 }
 
 void
 handle_set_percentage_progress(gchar *appName,
-                               gint percent,
+                               gchar *barText,
+                               gdouble percent,
                                GVariantIter *extraParams,
                                DsState  *ds_state)
 {
@@ -158,8 +164,13 @@ handle_set_percentage_progress(gchar *appName,
         return;
     }
     state->pulsed = FALSE;
-    gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(state->progressBar), ((gdouble)percent) / 100.0);
+    gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(state->progressBar), percent);
     gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
+    if ((barText != NULL) && (barText[0] == 0)) {
+        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), NULL);
+    } else {
+        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
+    }
 }
 
 RefreshState *

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -30,17 +30,23 @@ typedef struct {
     gchar                *lockFile;
     guint                 timeoutId;
     guint                 closeId;
+    gboolean              pulsed;
 } RefreshState;
 
-void
-handle_application_is_being_refreshed(gchar *appName,
-                                      gchar *lockFilePath,
-                                      GVariantIter *extraParams,
-                                      DsState  *ds_state);
-void
-handle_close_application_window(gchar *appName,
+void handle_application_is_being_refreshed(gchar *appName,
+                                           gchar *lockFilePath,
+                                           GVariantIter *extraParams,
+                                           DsState  *ds_state);
+void handle_close_application_window(gchar *appName,
+                                     GVariantIter *extraParams,
+                                     DsState  *ds_state);
+void handle_set_pulsed_progress(gchar *appName,
                                 GVariantIter *extraParams,
                                 DsState  *ds_state);
+void handle_set_percentage_progress(gchar *appName,
+                                    gint percentage,
+                                    GVariantIter *extraParams,
+                                    DsState  *ds_state);
 RefreshState *refresh_state_new(DsState *state,
                                 gchar *appName);
 

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -41,10 +41,12 @@ void handle_close_application_window(gchar *appName,
                                      GVariantIter *extraParams,
                                      DsState  *ds_state);
 void handle_set_pulsed_progress(gchar *appName,
+                                gchar *barText,
                                 GVariantIter *extraParams,
                                 DsState  *ds_state);
 void handle_set_percentage_progress(gchar *appName,
-                                    gint percentage,
+                                    gchar *barText,
+                                    gdouble percentage,
                                     GVariantIter *extraParams,
                                     DsState  *ds_state);
 RefreshState *refresh_state_new(DsState *state,


### PR DESCRIPTION
This MR adds two new DBus methods that allow to set a percentage value in the progress bar, or set again the pulsing bar.

This will be useful to give to the user more info about how the snap download is going.