### PR TITLE
Enforce a code style

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,20 @@
+name: Formatting
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Verify formatting
+        run: |
+          passed=true
+          for file in src/*.[ch] ; do clang-format $file > $file.formatted ; echo $file ; diff $file $file.formatted ; if [ $? != 0 ]; then passed=false ; fi ; rm $file.formatted ; done
+          if [ $passed = false ]; then exit 1; fi

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -16,82 +16,67 @@
  */
 
 #include "dbus.h"
-#include "refresh_status.h"
 #include "io.snapcraft.SnapDesktopIntegration.h"
+#include "refresh_status.h"
 
-static gboolean
-dbus_handle_application_is_being_refreshed (SnapDesktopIntegration *skeleton,
-                                            GDBusMethodInvocation *invocation,
-                                            gchar *snapName,
-                                            gchar *lockFilePath,
-                                            GVariantIter *extraParams,
-                                            gpointer data) {
+static gboolean dbus_handle_application_is_being_refreshed(
+    SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
+    gchar *snapName, gchar *lockFilePath, GVariantIter *extraParams,
+    gpointer data) {
 
-    handle_application_is_being_refreshed(snapName, lockFilePath, extraParams, data);
-    snap_desktop_integration_complete_application_is_being_refreshed(skeleton, invocation);
-    return TRUE;
+  handle_application_is_being_refreshed(snapName, lockFilePath, extraParams,
+                                        data);
+  snap_desktop_integration_complete_application_is_being_refreshed(skeleton,
+                                                                   invocation);
+  return TRUE;
 }
 
-static gboolean
-dbus_handle_close_application_window (SnapDesktopIntegration *skeleton,
-                                      GDBusMethodInvocation *invocation,
-                                      gchar *snapName,
-                                      GVariantIter *extraParams,
-                                      gpointer data) {
+static gboolean dbus_handle_close_application_window(
+    SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
+    gchar *snapName, GVariantIter *extraParams, gpointer data) {
 
-    handle_close_application_window(snapName, extraParams, data);
-    snap_desktop_integration_complete_application_refresh_completed(skeleton, invocation);
-    return TRUE;
+  handle_close_application_window(snapName, extraParams, data);
+  snap_desktop_integration_complete_application_refresh_completed(skeleton,
+                                                                  invocation);
+  return TRUE;
 }
 
-static gboolean
-dbus_handle_set_pulsed_progress (SnapDesktopIntegration *skeleton,
-                                 GDBusMethodInvocation *invocation,
-                                 gchar *snapName,
-                                 gchar *barText,
-                                 GVariantIter *extraParams,
-                                 gpointer data) {
+static gboolean dbus_handle_set_pulsed_progress(
+    SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
+    gchar *snapName, gchar *barText, GVariantIter *extraParams, gpointer data) {
 
-    handle_set_pulsed_progress(snapName, barText, extraParams, data);
-    snap_desktop_integration_complete_application_refresh_pulsed(skeleton, invocation);
-    return TRUE;
+  handle_set_pulsed_progress(snapName, barText, extraParams, data);
+  snap_desktop_integration_complete_application_refresh_pulsed(skeleton,
+                                                               invocation);
+  return TRUE;
 }
 
-static gboolean
-dbus_handle_set_percentage_progress (SnapDesktopIntegration *skeleton,
-                                     GDBusMethodInvocation *invocation,
-                                     gchar *snapName,
-                                     gchar *barText,
-                                     gdouble percentage,
-                                     GVariantIter *extraParams,
-                                     gpointer data) {
+static gboolean dbus_handle_set_percentage_progress(
+    SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
+    gchar *snapName, gchar *barText, gdouble percentage,
+    GVariantIter *extraParams, gpointer data) {
 
-    handle_set_percentage_progress(snapName, barText, percentage, extraParams, data);
-    snap_desktop_integration_complete_application_refresh_percentage(skeleton, invocation);
-    return TRUE;
+  handle_set_percentage_progress(snapName, barText, percentage, extraParams,
+                                 data);
+  snap_desktop_integration_complete_application_refresh_percentage(skeleton,
+                                                                   invocation);
+  return TRUE;
 }
 
-gboolean
-register_dbus (GDBusConnection  *connection,
-               DsState          *state,
-               GError          **error)
-{
+gboolean register_dbus(GDBusConnection *connection, DsState *state,
+                       GError **error) {
 
-    state->skeleton = snap_desktop_integration_skeleton_new();
-    g_signal_connect(state->skeleton, "handle_application_is_being_refreshed",
-                     G_CALLBACK (dbus_handle_application_is_being_refreshed),
-                     state);
-    g_signal_connect(state->skeleton, "handle_application_refresh_completed",
-                     G_CALLBACK (dbus_handle_close_application_window),
-                     state);
-    g_signal_connect(state->skeleton, "handle_application_refresh_pulsed",
-                     G_CALLBACK (dbus_handle_set_pulsed_progress),
-                     state);
-    g_signal_connect(state->skeleton, "handle_application_refresh_percentage",
-                     G_CALLBACK (dbus_handle_set_percentage_progress),
-                     state);
-    return g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON(state->skeleton),
-                                             connection,
-                                             "/io/snapcraft/SnapDesktopIntegration",
-                                             error);
+  state->skeleton = snap_desktop_integration_skeleton_new();
+  g_signal_connect(state->skeleton, "handle_application_is_being_refreshed",
+                   G_CALLBACK(dbus_handle_application_is_being_refreshed),
+                   state);
+  g_signal_connect(state->skeleton, "handle_application_refresh_completed",
+                   G_CALLBACK(dbus_handle_close_application_window), state);
+  g_signal_connect(state->skeleton, "handle_application_refresh_pulsed",
+                   G_CALLBACK(dbus_handle_set_pulsed_progress), state);
+  g_signal_connect(state->skeleton, "handle_application_refresh_percentage",
+                   G_CALLBACK(dbus_handle_set_percentage_progress), state);
+  return g_dbus_interface_skeleton_export(
+      G_DBUS_INTERFACE_SKELETON(state->skeleton), connection,
+      "/io/snapcraft/SnapDesktopIntegration", error);
 }

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -20,9 +20,7 @@
 
 #include "ds_state.h"
 
-gboolean
-register_dbus (GDBusConnection  *connection,
-               DsState          *state,
-               GError          **error);
+gboolean register_dbus(GDBusConnection *connection, DsState *state,
+                       GError **error);
 
 #endif //__DBUS_H__

--- a/src/ds_state.h
+++ b/src/ds_state.h
@@ -18,37 +18,37 @@
 #ifndef __DS_STATE_H__
 #define __DS_STATE_H__
 
-#include <gtk/gtk.h>
-#include <snapd-glib/snapd-glib.h>
-#include <libnotify/notify.h>
 #include "io.snapcraft.SnapDesktopIntegration.h"
+#include <gtk/gtk.h>
+#include <libnotify/notify.h>
+#include <snapd-glib/snapd-glib.h>
 
 typedef struct {
-    SnapDesktopIntegration *skeleton;
+  SnapDesktopIntegration *skeleton;
 
-    GtkSettings *settings;
-    SnapdClient *client;
-    GtkApplication *app;
+  GtkSettings *settings;
+  SnapdClient *client;
+  GtkApplication *app;
 
-    /* Timer to delay checking after theme changes */
-    guint check_delay_timer_id;
+  /* Timer to delay checking after theme changes */
+  guint check_delay_timer_id;
 
-    /* Name of current themes and their status in snapd. */
-    gchar *gtk_theme_name;
-    SnapdThemeStatus gtk_theme_status;
-    gchar *icon_theme_name;
-    SnapdThemeStatus icon_theme_status;
-    gchar *cursor_theme_name;
-    SnapdThemeStatus cursor_theme_status;
-    gchar *sound_theme_name;
-    SnapdThemeStatus sound_theme_status;
+  /* Name of current themes and their status in snapd. */
+  gchar *gtk_theme_name;
+  SnapdThemeStatus gtk_theme_status;
+  gchar *icon_theme_name;
+  SnapdThemeStatus icon_theme_status;
+  gchar *cursor_theme_name;
+  SnapdThemeStatus cursor_theme_status;
+  gchar *sound_theme_name;
+  SnapdThemeStatus sound_theme_status;
 
-    /* The desktop notifications */
-    NotifyNotification *install_notification;
-    NotifyNotification *progress_notification;
+  /* The desktop notifications */
+  NotifyNotification *install_notification;
+  NotifyNotification *progress_notification;
 
-    /* The list of current refresh popups */
-    GList *refreshing_list;
+  /* The list of current refresh popups */
+  GList *refreshing_list;
 } DsState;
 
 #endif // __DS_STATE_H__

--- a/src/main.c
+++ b/src/main.c
@@ -15,521 +15,485 @@
  *
  */
 
+#include "config.h"
+#include <errno.h>
 #include <gtk/gtk.h>
-#include <snapd-glib/snapd-glib.h>
+#include <libintl.h>
 #include <libnotify/notify.h>
 #include <locale.h>
-#include <libintl.h>
-#include "config.h"
-#include <unistd.h>
-#include <sys/wait.h>
-#include <errno.h>
 #include <signal.h>
+#include <snapd-glib/snapd-glib.h>
+#include <sys/wait.h>
 #include <syslog.h>
+#include <unistd.h>
 
-#include "ds_state.h"
 #include "dbus.h"
-#include "refresh_status.h"
-#include "org.freedesktop.login1.h"
+#include "ds_state.h"
 #include "org.freedesktop.login1.Session.h"
+#include "org.freedesktop.login1.h"
+#include "refresh_status.h"
 
-/* Number of second to wait after a theme change before checking for installed snaps. */
+/* Number of second to wait after a theme change before checking for installed
+ * snaps. */
 #define CHECK_THEME_TIMEOUT_SECONDS 1
-
 
 static Login1Manager *login_manager = NULL;
 
-static void
-ds_state_free(DsState *state)
-{
-    g_clear_object(&state->skeleton);
-    g_clear_object(&state->settings);
-    g_clear_object(&state->client);
-    g_clear_handle_id(&state->check_delay_timer_id, g_source_remove);
-    g_clear_pointer(&state->gtk_theme_name, g_free);
-    g_clear_pointer(&state->icon_theme_name, g_free);
-    g_clear_pointer(&state->cursor_theme_name, g_free);
-    g_clear_pointer(&state->sound_theme_name, g_free);
-    g_clear_object(&state->install_notification);
-    g_clear_object(&state->progress_notification);
-    g_list_free_full(state->refreshing_list, (GDestroyNotify)refresh_state_free);
-    g_free(state);
+static void ds_state_free(DsState *state) {
+  g_clear_object(&state->skeleton);
+  g_clear_object(&state->settings);
+  g_clear_object(&state->client);
+  g_clear_handle_id(&state->check_delay_timer_id, g_source_remove);
+  g_clear_pointer(&state->gtk_theme_name, g_free);
+  g_clear_pointer(&state->icon_theme_name, g_free);
+  g_clear_pointer(&state->cursor_theme_name, g_free);
+  g_clear_pointer(&state->sound_theme_name, g_free);
+  g_clear_object(&state->install_notification);
+  g_clear_object(&state->progress_notification);
+  g_list_free_full(state->refreshing_list, (GDestroyNotify)refresh_state_free);
+  g_free(state);
 }
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(DsState, ds_state_free);
 
-static void
-install_themes_cb(GObject *object, GAsyncResult *result, gpointer user_data)
-{
-    DsState *state = user_data;
-    g_autoptr(GError) error = NULL;
+static void install_themes_cb(GObject *object, GAsyncResult *result,
+                              gpointer user_data) {
+  DsState *state = user_data;
+  g_autoptr(GError) error = NULL;
 
-    if (snapd_client_install_themes_finish(SNAPD_CLIENT (object), result, &error)) {
-        g_message("Installation complete.\n");
-        notify_notification_update(state->progress_notification,
-        _("Installing missing theme snaps:"),
+  if (snapd_client_install_themes_finish(SNAPD_CLIENT(object), result,
+                                         &error)) {
+    g_message("Installation complete.\n");
+    notify_notification_update(
+        state->progress_notification, _("Installing missing theme snaps:"),
         /// TRANSLATORS: installing a missing theme snap succeed
         _("Complete."), "dialog-information");
-    } else {
-        g_message("Installation failed: %s\n", error->message);
-        gchar *error_message;
-        switch (error->code) {
-        case SNAPD_ERROR_AUTH_CANCELLED:
-            /// TRANSLATORS: installing a missing theme snap was cancelled by the user
-            error_message = _("Canceled by the user.");
-            break;
-        default:
-            /// TRANSLATORS: installing a missing theme snap failed
-            error_message = _("Failed.");
-            break;
-        }
-        notify_notification_update(state->progress_notification,
-        _("Installing missing theme snaps:"),
-        error_message,
-        "dialog-information");
+  } else {
+    g_message("Installation failed: %s\n", error->message);
+    gchar *error_message;
+    switch (error->code) {
+    case SNAPD_ERROR_AUTH_CANCELLED:
+      /// TRANSLATORS: installing a missing theme snap was cancelled by the user
+      error_message = _("Canceled by the user.");
+      break;
+    default:
+      /// TRANSLATORS: installing a missing theme snap failed
+      error_message = _("Failed.");
+      break;
     }
+    notify_notification_update(state->progress_notification,
+                               _("Installing missing theme snaps:"),
+                               error_message, "dialog-information");
+  }
 
+  notify_notification_show(state->progress_notification, NULL);
+  g_clear_object(&state->progress_notification);
+}
+
+static void notification_closed_cb(NotifyNotification *notification,
+                                   DsState *state) {
+  /* Notification has been closed: */
+  g_clear_object(&state->install_notification);
+}
+
+static void notify_cb(NotifyNotification *notification, char *action,
+                      gpointer user_data) {
+  DsState *state = user_data;
+
+  if ((strcmp(action, "yes") == 0) || (strcmp(action, "default") == 0)) {
+    g_message("Installing missing theme snaps...\n");
+    state->progress_notification = notify_notification_new(
+        _("Installing missing theme snaps:"), "...", "dialog-information");
     notify_notification_show(state->progress_notification, NULL);
-    g_clear_object(&state->progress_notification);
-}
-
-static void
-notification_closed_cb(NotifyNotification *notification, DsState *state) {
-    /* Notification has been closed: */
-    g_clear_object(&state->install_notification);
-}
-
-static void
-notify_cb(NotifyNotification *notification, char *action, gpointer user_data) {
-    DsState *state = user_data;
-
-    if ((strcmp(action, "yes") == 0) || (strcmp(action, "default") == 0)) {
-        g_message("Installing missing theme snaps...\n");
-        state->progress_notification = notify_notification_new(
-            _("Installing missing theme snaps:"),
-            "...",
-            "dialog-information");
-        notify_notification_show(state->progress_notification, NULL);
-
-        g_autoptr(GPtrArray) gtk_theme_names = g_ptr_array_new();
-        if (state->gtk_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
-            g_ptr_array_add(gtk_theme_names, state->gtk_theme_name);
-        }
-        g_ptr_array_add(gtk_theme_names, NULL);
-        g_autoptr(GPtrArray) icon_theme_names = g_ptr_array_new();
-        if (state->icon_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
-            g_ptr_array_add(icon_theme_names, state->icon_theme_name);
-        }
-        if (state->cursor_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
-            g_ptr_array_add(icon_theme_names, state->cursor_theme_name);
-        }
-        g_ptr_array_add(icon_theme_names, NULL);
-        g_autoptr(GPtrArray) sound_theme_names = g_ptr_array_new();
-        if (state->sound_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
-            g_ptr_array_add(sound_theme_names, state->sound_theme_name);
-        }
-        g_ptr_array_add(sound_theme_names, NULL);
-        snapd_client_install_themes_async(state->client,
-                                          (gchar**)gtk_theme_names->pdata,
-                                          (gchar**)icon_theme_names->pdata,
-                                          (gchar**)sound_theme_names->pdata,
-                                          NULL, NULL, NULL, install_themes_cb, state);
-    }
-}
-
-static void
-show_install_notification (DsState *state)
-{
-    /* If we've already displayed a notification, do nothing */
-    if (state->install_notification != NULL)
-        return;
-
-    state->install_notification = notify_notification_new(
-        _("Some required theme snaps are missing."),
-        _("Would you like to install them now?"),
-        "dialog-question");
-    g_signal_connect(state->install_notification, "closed",
-                     G_CALLBACK(notification_closed_cb), state);
-    notify_notification_set_timeout(state->install_notification, NOTIFY_EXPIRES_NEVER);
-    notify_notification_add_action(state->install_notification,
-        "yes",
-        /// TRANSLATORS: answer to the question "Would you like to install them now?" referred to snap themes
-        _("Yes"),
-        notify_cb,
-        state,
-        NULL);
-    notify_notification_add_action(state->install_notification,
-        "no",
-        /// TRANSLATORS: answer to the question "Would you like to install them now?" referred to snap themes
-        _("No"),
-        notify_cb,
-        state,
-        NULL);
-    notify_notification_add_action(state->install_notification, "default", "default", notify_cb, state, NULL);
-
-    notify_notification_show(state->install_notification, NULL);
-}
-
-static void
-check_themes_cb(GObject *object, GAsyncResult *result, gpointer user_data)
-{
-    DsState *state = user_data;
-
-    g_autoptr(GHashTable) gtk_theme_status = NULL;
-    g_autoptr(GHashTable) icon_theme_status = NULL;
-    g_autoptr(GHashTable) sound_theme_status = NULL;
-    g_autoptr(GError) error = NULL;
-    if (!snapd_client_check_themes_finish(SNAPD_CLIENT(object), result, &gtk_theme_status, &icon_theme_status, &sound_theme_status, &error)) {
-        g_warning("Could not check themes: %s", error->message);
-        return;
-    }
-
-    if (state->gtk_theme_name)
-        state->gtk_theme_status = GPOINTER_TO_INT (g_hash_table_lookup (gtk_theme_status, state->gtk_theme_name));
-    else
-        state->gtk_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
-    if (state->icon_theme_name)
-        state->icon_theme_status = GPOINTER_TO_INT (g_hash_table_lookup (icon_theme_status, state->icon_theme_name));
-    else
-        state->icon_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
-    if (state->cursor_theme_name)
-        state->cursor_theme_status = GPOINTER_TO_INT (g_hash_table_lookup (icon_theme_status, state->cursor_theme_name));
-    else
-        state->cursor_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
-    if (state->sound_theme_name)
-        state->sound_theme_status = GPOINTER_TO_INT (g_hash_table_lookup (sound_theme_status, state->sound_theme_name));
-    else
-        state->sound_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
-
-    gboolean themes_available = state->gtk_theme_status == SNAPD_THEME_STATUS_AVAILABLE ||
-                                state->icon_theme_status == SNAPD_THEME_STATUS_AVAILABLE ||
-                                state->cursor_theme_status == SNAPD_THEME_STATUS_AVAILABLE ||
-                                state->sound_theme_status == SNAPD_THEME_STATUS_AVAILABLE;
-
-    if (!themes_available) {
-        g_message("All available theme snaps installed\n");
-        return;
-    }
-
-    g_message("Missing theme snaps\n");
-
-    show_install_notification(state);
-}
-
-static gboolean
-get_themes_cb(DsState *state)
-{
-    state->check_delay_timer_id = 0;
-
-    g_autofree gchar *gtk_theme_name = NULL;
-    g_autofree gchar *icon_theme_name = NULL;
-    g_autofree gchar *cursor_theme_name = NULL;
-    g_autofree gchar *sound_theme_name = NULL;
-    g_object_get(state->settings,
-                 "gtk-theme-name", &gtk_theme_name,
-                 "gtk-icon-theme-name", &icon_theme_name,
-                 "gtk-cursor-theme-name", &cursor_theme_name,
-                 "gtk-sound-theme-name", &sound_theme_name,
-                 NULL);
-
-    /* If nothing has changed, we're done */
-    if (g_strcmp0(state->gtk_theme_name, gtk_theme_name) == 0 &&
-        g_strcmp0(state->icon_theme_name, icon_theme_name) == 0 &&
-        g_strcmp0(state->cursor_theme_name, cursor_theme_name) == 0 &&
-        g_strcmp0(state->sound_theme_name, sound_theme_name) == 0) {
-        return G_SOURCE_REMOVE;
-    }
-
-    g_message("New theme: gtk=%s icon=%s cursor=%s, sound=%s",
-              gtk_theme_name,
-              icon_theme_name,
-              cursor_theme_name,
-              sound_theme_name);
-
-    g_free (state->gtk_theme_name);
-    state->gtk_theme_name = g_steal_pointer(&gtk_theme_name);
-    state->gtk_theme_status = 0;
-
-    g_free (state->icon_theme_name);
-    state->icon_theme_name = g_steal_pointer(&icon_theme_name);
-    state->icon_theme_status = 0;
-
-    g_free (state->cursor_theme_name);
-    state->cursor_theme_name = g_steal_pointer(&cursor_theme_name);
-    state->cursor_theme_status = 0;
-
-    g_free (state->sound_theme_name);
-    state->sound_theme_name = g_steal_pointer(&sound_theme_name);
-    state->sound_theme_status = 0;
 
     g_autoptr(GPtrArray) gtk_theme_names = g_ptr_array_new();
-    if (state->gtk_theme_name)
-        g_ptr_array_add(gtk_theme_names, state->gtk_theme_name);
+    if (state->gtk_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
+      g_ptr_array_add(gtk_theme_names, state->gtk_theme_name);
+    }
     g_ptr_array_add(gtk_theme_names, NULL);
-
     g_autoptr(GPtrArray) icon_theme_names = g_ptr_array_new();
-    if (state->icon_theme_name)
-        g_ptr_array_add(icon_theme_names, state->icon_theme_name);
-    if (state->cursor_theme_name)
-        g_ptr_array_add(icon_theme_names, state->cursor_theme_name);
+    if (state->icon_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
+      g_ptr_array_add(icon_theme_names, state->icon_theme_name);
+    }
+    if (state->cursor_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
+      g_ptr_array_add(icon_theme_names, state->cursor_theme_name);
+    }
     g_ptr_array_add(icon_theme_names, NULL);
-
     g_autoptr(GPtrArray) sound_theme_names = g_ptr_array_new();
-    if (state->sound_theme_name)
-        g_ptr_array_add(sound_theme_names, state->sound_theme_name);
+    if (state->sound_theme_status == SNAPD_THEME_STATUS_AVAILABLE) {
+      g_ptr_array_add(sound_theme_names, state->sound_theme_name);
+    }
     g_ptr_array_add(sound_theme_names, NULL);
-
-    snapd_client_check_themes_async(state->client,
-                                    (gchar**)gtk_theme_names->pdata,
-                                    (gchar**)icon_theme_names->pdata,
-                                    (gchar**)sound_theme_names->pdata,
-                                    NULL, check_themes_cb, state);
-
-    return G_SOURCE_REMOVE;
+    snapd_client_install_themes_async(
+        state->client, (gchar **)gtk_theme_names->pdata,
+        (gchar **)icon_theme_names->pdata, (gchar **)sound_theme_names->pdata,
+        NULL, NULL, NULL, install_themes_cb, state);
+  }
 }
 
-static void
-queue_check_theme(DsState *state)
-{
-    /* Delay processing the theme, in case multiple themes are being changed at the same time. */
-    g_clear_handle_id(&state->check_delay_timer_id, g_source_remove);
-    state->check_delay_timer_id = g_timeout_add_seconds(
-        CHECK_THEME_TIMEOUT_SECONDS, G_SOURCE_FUNC(get_themes_cb), state);
+static void show_install_notification(DsState *state) {
+  /* If we've already displayed a notification, do nothing */
+  if (state->install_notification != NULL)
+    return;
+
+  state->install_notification = notify_notification_new(
+      _("Some required theme snaps are missing."),
+      _("Would you like to install them now?"), "dialog-question");
+  g_signal_connect(state->install_notification, "closed",
+                   G_CALLBACK(notification_closed_cb), state);
+  notify_notification_set_timeout(state->install_notification,
+                                  NOTIFY_EXPIRES_NEVER);
+  notify_notification_add_action(
+      state->install_notification, "yes",
+      /// TRANSLATORS: answer to the question "Would you like to install them
+      /// now?" referred to snap themes
+      _("Yes"), notify_cb, state, NULL);
+  notify_notification_add_action(
+      state->install_notification, "no",
+      /// TRANSLATORS: answer to the question "Would you like to install them
+      /// now?" referred to snap themes
+      _("No"), notify_cb, state, NULL);
+  notify_notification_add_action(state->install_notification, "default",
+                                 "default", notify_cb, state, NULL);
+
+  notify_notification_show(state->install_notification, NULL);
+}
+
+static void check_themes_cb(GObject *object, GAsyncResult *result,
+                            gpointer user_data) {
+  DsState *state = user_data;
+
+  g_autoptr(GHashTable) gtk_theme_status = NULL;
+  g_autoptr(GHashTable) icon_theme_status = NULL;
+  g_autoptr(GHashTable) sound_theme_status = NULL;
+  g_autoptr(GError) error = NULL;
+  if (!snapd_client_check_themes_finish(SNAPD_CLIENT(object), result,
+                                        &gtk_theme_status, &icon_theme_status,
+                                        &sound_theme_status, &error)) {
+    g_warning("Could not check themes: %s", error->message);
+    return;
+  }
+
+  if (state->gtk_theme_name)
+    state->gtk_theme_status = GPOINTER_TO_INT(
+        g_hash_table_lookup(gtk_theme_status, state->gtk_theme_name));
+  else
+    state->gtk_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
+  if (state->icon_theme_name)
+    state->icon_theme_status = GPOINTER_TO_INT(
+        g_hash_table_lookup(icon_theme_status, state->icon_theme_name));
+  else
+    state->icon_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
+  if (state->cursor_theme_name)
+    state->cursor_theme_status = GPOINTER_TO_INT(
+        g_hash_table_lookup(icon_theme_status, state->cursor_theme_name));
+  else
+    state->cursor_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
+  if (state->sound_theme_name)
+    state->sound_theme_status = GPOINTER_TO_INT(
+        g_hash_table_lookup(sound_theme_status, state->sound_theme_name));
+  else
+    state->sound_theme_status = SNAPD_THEME_STATUS_UNAVAILABLE;
+
+  gboolean themes_available =
+      state->gtk_theme_status == SNAPD_THEME_STATUS_AVAILABLE ||
+      state->icon_theme_status == SNAPD_THEME_STATUS_AVAILABLE ||
+      state->cursor_theme_status == SNAPD_THEME_STATUS_AVAILABLE ||
+      state->sound_theme_status == SNAPD_THEME_STATUS_AVAILABLE;
+
+  if (!themes_available) {
+    g_message("All available theme snaps installed\n");
+    return;
+  }
+
+  g_message("Missing theme snaps\n");
+
+  show_install_notification(state);
+}
+
+static gboolean get_themes_cb(DsState *state) {
+  state->check_delay_timer_id = 0;
+
+  g_autofree gchar *gtk_theme_name = NULL;
+  g_autofree gchar *icon_theme_name = NULL;
+  g_autofree gchar *cursor_theme_name = NULL;
+  g_autofree gchar *sound_theme_name = NULL;
+  g_object_get(state->settings, "gtk-theme-name", &gtk_theme_name,
+               "gtk-icon-theme-name", &icon_theme_name, "gtk-cursor-theme-name",
+               &cursor_theme_name, "gtk-sound-theme-name", &sound_theme_name,
+               NULL);
+
+  /* If nothing has changed, we're done */
+  if (g_strcmp0(state->gtk_theme_name, gtk_theme_name) == 0 &&
+      g_strcmp0(state->icon_theme_name, icon_theme_name) == 0 &&
+      g_strcmp0(state->cursor_theme_name, cursor_theme_name) == 0 &&
+      g_strcmp0(state->sound_theme_name, sound_theme_name) == 0) {
+    return G_SOURCE_REMOVE;
+  }
+
+  g_message("New theme: gtk=%s icon=%s cursor=%s, sound=%s", gtk_theme_name,
+            icon_theme_name, cursor_theme_name, sound_theme_name);
+
+  g_free(state->gtk_theme_name);
+  state->gtk_theme_name = g_steal_pointer(&gtk_theme_name);
+  state->gtk_theme_status = 0;
+
+  g_free(state->icon_theme_name);
+  state->icon_theme_name = g_steal_pointer(&icon_theme_name);
+  state->icon_theme_status = 0;
+
+  g_free(state->cursor_theme_name);
+  state->cursor_theme_name = g_steal_pointer(&cursor_theme_name);
+  state->cursor_theme_status = 0;
+
+  g_free(state->sound_theme_name);
+  state->sound_theme_name = g_steal_pointer(&sound_theme_name);
+  state->sound_theme_status = 0;
+
+  g_autoptr(GPtrArray) gtk_theme_names = g_ptr_array_new();
+  if (state->gtk_theme_name)
+    g_ptr_array_add(gtk_theme_names, state->gtk_theme_name);
+  g_ptr_array_add(gtk_theme_names, NULL);
+
+  g_autoptr(GPtrArray) icon_theme_names = g_ptr_array_new();
+  if (state->icon_theme_name)
+    g_ptr_array_add(icon_theme_names, state->icon_theme_name);
+  if (state->cursor_theme_name)
+    g_ptr_array_add(icon_theme_names, state->cursor_theme_name);
+  g_ptr_array_add(icon_theme_names, NULL);
+
+  g_autoptr(GPtrArray) sound_theme_names = g_ptr_array_new();
+  if (state->sound_theme_name)
+    g_ptr_array_add(sound_theme_names, state->sound_theme_name);
+  g_ptr_array_add(sound_theme_names, NULL);
+
+  snapd_client_check_themes_async(
+      state->client, (gchar **)gtk_theme_names->pdata,
+      (gchar **)icon_theme_names->pdata, (gchar **)sound_theme_names->pdata,
+      NULL, check_themes_cb, state);
+
+  return G_SOURCE_REMOVE;
+}
+
+static void queue_check_theme(DsState *state) {
+  /* Delay processing the theme, in case multiple themes are being changed at
+   * the same time. */
+  g_clear_handle_id(&state->check_delay_timer_id, g_source_remove);
+  state->check_delay_timer_id = g_timeout_add_seconds(
+      CHECK_THEME_TIMEOUT_SECONDS, G_SOURCE_FUNC(get_themes_cb), state);
 }
 
 static gchar *snapd_socket_path = NULL;
 
-static GOptionEntry entries[] =
-{
-   { "snapd-socket-path", 0, 0, G_OPTION_ARG_FILENAME, &snapd_socket_path, "Snapd socket path", "PATH" },
-   { NULL }
-};
+static GOptionEntry entries[] = {{"snapd-socket-path", 0, 0,
+                                  G_OPTION_ARG_FILENAME, &snapd_socket_path,
+                                  "Snapd socket path", "PATH"},
+                                 {NULL}};
 
-static gboolean
-session_is_desktop(const gchar *object_path) {
-    g_autoptr(OrgFreedesktopLogin1Session) session = NULL;
-    g_autoptr (GVariant) user = NULL;
-    GVariant *user_data = NULL; // this value belongs to the session proxy, so it must not be freed
-    const gchar *session_type = NULL; // this value belongs to the session proxy, so it must not be freed
+static gboolean session_is_desktop(const gchar *object_path) {
+  g_autoptr(OrgFreedesktopLogin1Session) session = NULL;
+  g_autoptr(GVariant) user = NULL;
+  GVariant *user_data =
+      NULL; // this value belongs to the session proxy, so it must not be freed
+  const gchar *session_type =
+      NULL; // this value belongs to the session proxy, so it must not be freed
 
-    session = org_freedesktop_login1_session_proxy_new_for_bus_sync(
-        G_BUS_TYPE_SYSTEM,
-        G_DBUS_PROXY_FLAGS_NONE,
-        "org.freedesktop.login1",
-        object_path,
-        NULL,
-        NULL
-    );
-    user_data = org_freedesktop_login1_session_get_user(session);
-    if (user_data == NULL) {
-        g_message("Failed to read the session user data. Forcing a reload.");
-        // if we can't read the data, we can't know whether we are in a desktop session or in a text one,
-        // so we will assume that we are in a session desktop to force a reload.
-        return TRUE;
-    }
-    user = g_variant_get_child_value(user_data, 0);
-    if (user == NULL) {
-        g_message("Failed to read the session user.");
-        return FALSE;
-    }
-    if (getuid() != g_variant_get_uint32(user)) {
-        // the new session isn't for our user
-        return FALSE;
-    }
-    session_type = org_freedesktop_login1_session_get_type_(session);
-    if (session_type == NULL) {
-        g_message("Failed to read the session type");
-        return FALSE;
-    }
-    if (!g_strcmp0("x11", session_type) ||
-        !g_strcmp0("wayland", session_type) ||
-        !g_strcmp0("mir", session_type)) {
-            // this is a graphical session
-            return TRUE;
-        }
+  session = org_freedesktop_login1_session_proxy_new_for_bus_sync(
+      G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, "org.freedesktop.login1",
+      object_path, NULL, NULL);
+  user_data = org_freedesktop_login1_session_get_user(session);
+  if (user_data == NULL) {
+    g_message("Failed to read the session user data. Forcing a reload.");
+    // if we can't read the data, we can't know whether we are in a desktop
+    // session or in a text one, so we will assume that we are in a session
+    // desktop to force a reload.
+    return TRUE;
+  }
+  user = g_variant_get_child_value(user_data, 0);
+  if (user == NULL) {
+    g_message("Failed to read the session user.");
     return FALSE;
+  }
+  if (getuid() != g_variant_get_uint32(user)) {
+    // the new session isn't for our user
+    return FALSE;
+  }
+  session_type = org_freedesktop_login1_session_get_type_(session);
+  if (session_type == NULL) {
+    g_message("Failed to read the session type");
+    return FALSE;
+  }
+  if (!g_strcmp0("x11", session_type) || !g_strcmp0("wayland", session_type) ||
+      !g_strcmp0("mir", session_type)) {
+    // this is a graphical session
+    return TRUE;
+  }
+  return FALSE;
 }
 
-static void
-new_session(Login1Manager *manager, gchar *session_id, const gchar *object_path, gpointer data) {
-    GMainLoop *loop = (GMainLoop*)data;
-    g_message("Detected new session %s at %s\n", session_id, object_path);
+static void new_session(Login1Manager *manager, gchar *session_id,
+                        const gchar *object_path, gpointer data) {
+  GMainLoop *loop = (GMainLoop *)data;
+  g_message("Detected new session %s at %s\n", session_id, object_path);
 
-    if (session_is_desktop(object_path)) {
-        g_message("The new session is of desktop type. Relaunching snapd-desktop-integration.");
+  if (session_is_desktop(object_path)) {
+    g_message("The new session is of desktop type. Relaunching "
+              "snapd-desktop-integration.");
+    g_main_loop_quit(loop);
+  }
+}
+
+static gboolean check_graphical_sessions(gpointer data) {
+  GMainLoop *loop = (GMainLoop *)data;
+
+  GVariant *sessions = NULL;
+  gboolean got_session_list;
+
+  got_session_list = login1_manager_call_list_sessions_sync(
+      login_manager, &sessions, NULL, NULL);
+
+  if (got_session_list) {
+    // check if there is already a graphical session opened for us, in which
+    // case we must just exit and let systemd to relaunch us, because it means
+    // that we run too early and the desktop wasn't still ready
+    for (int i = 0; i < g_variant_n_children(sessions); i++) {
+      GVariant *session = g_variant_get_child_value(sessions, i);
+      if (session == NULL) {
+        continue;
+      }
+      GVariant *session_object_variant = g_variant_get_child_value(session, 4);
+      const gchar *session_object =
+          g_variant_get_string(session_object_variant, NULL);
+      g_message("Checking session %s...", session_object);
+      if (session_is_desktop(session_object)) {
+        g_message("Is a desktop session! Forcing a reload.");
         g_main_loop_quit(loop);
+      }
+      g_variant_unref(session_object_variant);
+      g_variant_unref(session);
     }
+  } else {
+    g_message("Failed to get session list (check that login-session-observe "
+              "interface is connected). Forcing a reload.");
+    g_main_loop_quit(loop);
+  }
+  return G_SOURCE_REMOVE;
+}
+static void do_startup(GObject *object, gpointer data) {
+  DsState *state = (DsState *)data;
+  notify_init("snapd-desktop-integration");
+  state->settings = gtk_settings_get_default();
+  state->client = snapd_client_new();
+  state->app = GTK_APPLICATION(object);
+  if (!register_dbus(
+          g_application_get_dbus_connection(G_APPLICATION(state->app)), state,
+          NULL)) {
+    g_clear_object(&(state->skeleton));
+    g_message("Failed to export the DBus Desktop Integration API");
+  }
 }
 
-static gboolean
-check_graphical_sessions(gpointer data) {
-    GMainLoop *loop = (GMainLoop *)data;
+static void do_activate(GObject *object, gpointer data) {
+  DsState *state = (DsState *)data;
 
-    GVariant *sessions = NULL;
-    gboolean got_session_list;
+  // because, by default, there are no windows, so the application would quit
+  g_application_hold(G_APPLICATION(state->app));
 
-    got_session_list = login1_manager_call_list_sessions_sync(
-        login_manager,
-        &sessions,
-        NULL,
-        NULL
-    );
+  if (snapd_socket_path != NULL) {
+    snapd_client_set_socket_path(state->client, snapd_socket_path);
+  } else if (g_getenv("SNAP") != NULL) {
+    snapd_client_set_socket_path(state->client, "/run/snapd-snap.socket");
+  }
 
-    if (got_session_list) {
-        // check if there is already a graphical session opened for us, in which case we must just exit
-        // and let systemd to relaunch us, because it means that we run too early and the desktop
-        // wasn't still ready
-        for(int i=0; i<g_variant_n_children(sessions); i++) {
-            GVariant *session = g_variant_get_child_value(sessions, i);
-            if (session == NULL) {
-                continue;
-            }
-            GVariant *session_object_variant = g_variant_get_child_value(session, 4);
-            const gchar *session_object = g_variant_get_string(session_object_variant, NULL);
-            g_message("Checking session %s...", session_object);
-            if (session_is_desktop(session_object)) {
-                g_message("Is a desktop session! Forcing a reload.");
-                g_main_loop_quit(loop);
-            }
-            g_variant_unref(session_object_variant);
-            g_variant_unref(session);
-        }
-    } else {
-        g_message("Failed to get session list (check that login-session-observe interface is connected). Forcing a reload.");
-        g_main_loop_quit(loop);
-    }
-    return G_SOURCE_REMOVE;
-}
-static void
-do_startup (GObject  *object,
-            gpointer  data)
-{
-    DsState *state = (DsState *)data;
-    notify_init("snapd-desktop-integration");
-    state->settings = gtk_settings_get_default();
-    state->client = snapd_client_new();
-    state->app = GTK_APPLICATION (object);
-    if (!register_dbus(g_application_get_dbus_connection(G_APPLICATION(state->app)), state, NULL)) {
-        g_clear_object(&(state->skeleton));
-        g_message("Failed to export the DBus Desktop Integration API");
-    }
+  /* Listen for theme changes. */
+  g_signal_connect_swapped(state->settings, "notify::gtk-theme-name",
+                           G_CALLBACK(queue_check_theme), state);
+  g_signal_connect_swapped(state->settings, "notify::gtk-icon-theme-name",
+                           G_CALLBACK(queue_check_theme), state);
+  g_signal_connect_swapped(state->settings, "notify::gtk-cursor-theme-name",
+                           G_CALLBACK(queue_check_theme), state);
+  g_signal_connect_swapped(state->settings, "notify::gtk-sound-theme-name",
+                           G_CALLBACK(queue_check_theme), state);
+  get_themes_cb(state);
 }
 
-static void
-do_activate (GObject  *object,
-             gpointer  data)
-{
-    DsState *state = (DsState *)data;
-
-    // because, by default, there are no windows, so the application would quit
-    g_application_hold (G_APPLICATION (state->app));
-
-    if (snapd_socket_path != NULL) {
-        snapd_client_set_socket_path(state->client, snapd_socket_path);
-    } else if (g_getenv ("SNAP") != NULL) {
-        snapd_client_set_socket_path(state->client, "/run/snapd-snap.socket");
-    }
-
-    /* Listen for theme changes. */
-    g_signal_connect_swapped(state->settings, "notify::gtk-theme-name",
-                     G_CALLBACK(queue_check_theme), state);
-    g_signal_connect_swapped(state->settings, "notify::gtk-icon-theme-name",
-                     G_CALLBACK(queue_check_theme), state);
-    g_signal_connect_swapped(state->settings, "notify::gtk-cursor-theme-name",
-                     G_CALLBACK(queue_check_theme), state);
-    g_signal_connect_swapped(state->settings, "notify::gtk-sound-theme-name",
-                     G_CALLBACK(queue_check_theme), state);
-    get_themes_cb(state);
-}
-
-static void
-do_shutdown (GObject  *object,
-             gpointer  data)
-{
-    notify_uninit();
-}
+static void do_shutdown(GObject *object, gpointer data) { notify_uninit(); }
 
 static int global_retval = 0;
 
-void
-sighandler(int v)
-{
-    global_retval = 128 + v; // exit value is usually 128 + signal_id
+void sighandler(int v) {
+  global_retval = 128 + v; // exit value is usually 128 + signal_id
 }
 
-int
-main(int argc, char **argv)
-{
-    int retval;
-    int pid = fork();
-    if (pid != 0) {
-        if (pid > 0) {
-            // SIGTERM and SIGINT will be ignored, but
-            // will break WAITPID with a EINTR value in
-            // errno.
-            // This allows the program to always exit with
-            // a NO-ERROR value, and kill the child
-            struct sigaction signal_data;
-            signal_data.sa_handler = sighandler;
-            sigemptyset(&signal_data.sa_mask);
-            signal_data.sa_flags = 0;
-            sigaction(SIGTERM, &signal_data, NULL);
-            sigaction(SIGINT, &signal_data, NULL);
+int main(int argc, char **argv) {
+  int retval;
+  int pid = fork();
+  if (pid != 0) {
+    if (pid > 0) {
+      // SIGTERM and SIGINT will be ignored, but
+      // will break WAITPID with a EINTR value in
+      // errno.
+      // This allows the program to always exit with
+      // a NO-ERROR value, and kill the child
+      struct sigaction signal_data;
+      signal_data.sa_handler = sighandler;
+      sigemptyset(&signal_data.sa_mask);
+      signal_data.sa_flags = 0;
+      sigaction(SIGTERM, &signal_data, NULL);
+      sigaction(SIGINT, &signal_data, NULL);
 
-            retval = waitpid(pid, NULL, 0);
-            if ((retval < 0) && (errno == EINTR)) {
-                kill(pid, SIGTERM);
-                waitpid(pid, NULL, 0);
-            }
-        }
-        return global_retval;
+      retval = waitpid(pid, NULL, 0);
+      if ((retval < 0) && (errno == EINTR)) {
+        kill(pid, SIGTERM);
+        waitpid(pid, NULL, 0);
+      }
     }
+    return global_retval;
+  }
 
+  setlocale(LC_ALL, "");
+  bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
+  textdomain(GETTEXT_PACKAGE);
 
-    setlocale(LC_ALL, "");
-    bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
-    textdomain (GETTEXT_PACKAGE);
+  if (!gtk_init_check(&argc, &argv)) {
+    g_message("Failed to do gtk init. Waiting for a new session with desktop "
+              "capabilities.");
 
-    if (!gtk_init_check(&argc, &argv)) {
-        g_message("Failed to do gtk init. Waiting for a new session with desktop capabilities.");
-
-        GMainLoop *loop = g_main_loop_new(NULL, TRUE);
-        login_manager = login1_manager_proxy_new_for_bus_sync(
-            G_BUS_TYPE_SYSTEM,
-            G_DBUS_PROXY_FLAGS_NONE,
-            "org.freedesktop.login1",
-            "/org/freedesktop/login1",
-            NULL,
-            NULL
-        );
-        g_signal_connect(login_manager, "session-new", G_CALLBACK(new_session), loop);
-        // Check if we are already in a graphical session to avoid race conditions between
-        // the signals being connected and the main loop being run.
-        // This is a must because, sometimes, snapd-desktop-integration is launched "too quickly"
-        // and the desktop isn't ready, so gtk_init_check() fails but the session IS a graphical
-        // one. For that cases we do check if there is a graphical session active, and if that's
-        // the case, we must exit to let systemd relaunch us again, this time being able to get
-        // access to the session.
-        g_idle_add(check_graphical_sessions, loop);
-        g_main_loop_run(loop);
-        g_message("Loop exited. Forcing reload.");
-        return 0;
-    }
-
-    g_autoptr (GtkApplication) app = NULL;
-    g_autoptr(DsState) state = g_new0(DsState, 1);
-
-    app = gtk_application_new ("io.snapcraft.SnapDesktopIntegration",
-                               G_APPLICATION_ALLOW_REPLACEMENT | G_APPLICATION_REPLACE);
-    g_signal_connect (G_OBJECT (app), "startup", G_CALLBACK (do_startup), state);
-    g_signal_connect (G_OBJECT (app), "shutdown", G_CALLBACK (do_shutdown), state);
-    g_signal_connect (G_OBJECT (app), "activate", G_CALLBACK (do_activate), state);
-
-    g_application_add_main_option_entries (G_APPLICATION (app), entries);
-
-    g_application_run (G_APPLICATION (app), argc, argv);
-
-    // since it should never ends, if we reach here, we return 0 as error value to
-    // ensure that systemd will relaunch it.
+    GMainLoop *loop = g_main_loop_new(NULL, TRUE);
+    login_manager = login1_manager_proxy_new_for_bus_sync(
+        G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, "org.freedesktop.login1",
+        "/org/freedesktop/login1", NULL, NULL);
+    g_signal_connect(login_manager, "session-new", G_CALLBACK(new_session),
+                     loop);
+    // Check if we are already in a graphical session to avoid race conditions
+    // between the signals being connected and the main loop being run. This is
+    // a must because, sometimes, snapd-desktop-integration is launched "too
+    // quickly" and the desktop isn't ready, so gtk_init_check() fails but the
+    // session IS a graphical one. For that cases we do check if there is a
+    // graphical session active, and if that's the case, we must exit to let
+    // systemd relaunch us again, this time being able to get access to the
+    // session.
+    g_idle_add(check_graphical_sessions, loop);
+    g_main_loop_run(loop);
+    g_message("Loop exited. Forcing reload.");
     return 0;
+  }
+
+  g_autoptr(GtkApplication) app = NULL;
+  g_autoptr(DsState) state = g_new0(DsState, 1);
+
+  app = gtk_application_new("io.snapcraft.SnapDesktopIntegration",
+                            G_APPLICATION_ALLOW_REPLACEMENT |
+                                G_APPLICATION_REPLACE);
+  g_signal_connect(G_OBJECT(app), "startup", G_CALLBACK(do_startup), state);
+  g_signal_connect(G_OBJECT(app), "shutdown", G_CALLBACK(do_shutdown), state);
+  g_signal_connect(G_OBJECT(app), "activate", G_CALLBACK(do_activate), state);
+
+  g_application_add_main_option_entries(G_APPLICATION(app), entries);
+
+  g_application_run(G_APPLICATION(app), argc, argv);
+
+  // since it should never ends, if we reach here, we return 0 as error value to
+  // ensure that systemd will relaunch it.
+  return 0;
 }

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -16,193 +16,174 @@
  */
 
 #include "refresh_status.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <errno.h>
 #include "iresources.h"
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <libintl.h>
 
-gboolean
-on_delete_window(GtkWindow    *self,
-                 GdkEvent     *event,
-                 RefreshState *state)
-{
-    refresh_state_free (state);
-    return FALSE;
+gboolean on_delete_window(GtkWindow *self, GdkEvent *event,
+                          RefreshState *state) {
+  refresh_state_free(state);
+  return FALSE;
 }
 
-void
-on_hide_clicked(GtkButton *button,
-                RefreshState *state)
-{
-    refresh_state_free (state);
+void on_hide_clicked(GtkButton *button, RefreshState *state) {
+  refresh_state_free(state);
 }
 
-static gboolean
-refresh_progress_bar(RefreshState *state) {
-    struct stat statbuf;
-    if (state->pulsed) {
-        gtk_progress_bar_pulse(GTK_PROGRESS_BAR(state->progressBar));
-    }
-    if (state->lockFile == NULL) {
-        return G_SOURCE_CONTINUE;
-    }
-    if (stat(state->lockFile, &statbuf) != 0) {
-        if ((errno == ENOENT) || (errno == ENOTDIR)) {
-            refresh_state_free (state);
-            return G_SOURCE_REMOVE;
-        }
-    } else {
-        if (statbuf.st_size == 0) {
-            refresh_state_free (state);
-            return G_SOURCE_REMOVE;
-        }
-    }
+static gboolean refresh_progress_bar(RefreshState *state) {
+  struct stat statbuf;
+  if (state->pulsed) {
+    gtk_progress_bar_pulse(GTK_PROGRESS_BAR(state->progressBar));
+  }
+  if (state->lockFile == NULL) {
     return G_SOURCE_CONTINUE;
+  }
+  if (stat(state->lockFile, &statbuf) != 0) {
+    if ((errno == ENOENT) || (errno == ENOTDIR)) {
+      refresh_state_free(state);
+      return G_SOURCE_REMOVE;
+    }
+  } else {
+    if (statbuf.st_size == 0) {
+      refresh_state_free(state);
+      return G_SOURCE_REMOVE;
+    }
+  }
+  return G_SOURCE_CONTINUE;
 }
 
-static RefreshState *
-find_application(GList      *list,
-                 const char *appName)
-{
-    for (; list != NULL; list=list->next) {
-        RefreshState *state = (RefreshState *)list->data;
-        if (0 == g_strcmp0(state->appName->str, appName)) {
-            return state;
-        }
+static RefreshState *find_application(GList *list, const char *appName) {
+  for (; list != NULL; list = list->next) {
+    RefreshState *state = (RefreshState *)list->data;
+    if (0 == g_strcmp0(state->appName->str, appName)) {
+      return state;
     }
-    return NULL;
+  }
+  return NULL;
 }
 
-void
-handle_application_is_being_refreshed(gchar *appName,
-                                      gchar *lockFilePath,
-                                      GVariantIter *extraParams,
-                                      DsState  *ds_state)
-{
-    RefreshState *state = NULL;
-    g_autoptr(GtkWidget) container = NULL;
-    g_autoptr(GtkWidget) label = NULL;
-    g_autoptr(GString) labelText = NULL;
-    g_autoptr(GtkBuilder) builder = NULL;
+void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,
+                                           GVariantIter *extraParams,
+                                           DsState *ds_state) {
+  RefreshState *state = NULL;
+  g_autoptr(GtkWidget) container = NULL;
+  g_autoptr(GtkWidget) label = NULL;
+  g_autoptr(GString) labelText = NULL;
+  g_autoptr(GtkBuilder) builder = NULL;
 
-    state = find_application(ds_state->refreshing_list, appName);
-    if (state != NULL) {
-        gtk_widget_hide(GTK_WIDGET(state->window));
-        gtk_window_present(GTK_WINDOW(state->window));
-        return;
-    }
+  state = find_application(ds_state->refreshing_list, appName);
+  if (state != NULL) {
+    gtk_widget_hide(GTK_WIDGET(state->window));
+    gtk_window_present(GTK_WINDOW(state->window));
+    return;
+  }
 
-    state = refresh_state_new(ds_state, appName);
-    if (*lockFilePath == 0) {
-        state->lockFile = NULL;
-    } else {
-        state->lockFile = g_strdup(lockFilePath);
-    }
-    builder = gtk_builder_new_from_resource("/io/snapcraft/SnapDesktopIntegration/snap_is_being_refreshed.ui");
-    gtk_builder_connect_signals(builder, state);
-    state->window = GTK_APPLICATION_WINDOW(g_object_ref(gtk_builder_get_object(builder, "main_window")));
-    label = GTK_WIDGET(g_object_ref(gtk_builder_get_object(builder, "app_label")));
-    state->progressBar = GTK_WIDGET(g_object_ref(gtk_builder_get_object(builder, "progress_bar")));
+  state = refresh_state_new(ds_state, appName);
+  if (*lockFilePath == 0) {
+    state->lockFile = NULL;
+  } else {
+    state->lockFile = g_strdup(lockFilePath);
+  }
+  builder = gtk_builder_new_from_resource(
+      "/io/snapcraft/SnapDesktopIntegration/snap_is_being_refreshed.ui");
+  gtk_builder_connect_signals(builder, state);
+  state->window = GTK_APPLICATION_WINDOW(
+      g_object_ref(gtk_builder_get_object(builder, "main_window")));
+  label =
+      GTK_WIDGET(g_object_ref(gtk_builder_get_object(builder, "app_label")));
+  state->progressBar =
+      GTK_WIDGET(g_object_ref(gtk_builder_get_object(builder, "progress_bar")));
 
-    labelText = g_string_new("");
-    g_string_printf(labelText, _("Please wait while '%s' is being refreshed to the latest version.\nThis process may take a few minutes."), appName);
-    gtk_label_set_text(GTK_LABEL(label), labelText->str);
+  labelText = g_string_new("");
+  g_string_printf(labelText,
+                  _("Please wait while '%s' is being refreshed to the latest "
+                    "version.\nThis process may take a few minutes."),
+                  appName);
+  gtk_label_set_text(GTK_LABEL(label), labelText->str);
 
-    state->timeoutId = g_timeout_add(200, G_SOURCE_FUNC(refresh_progress_bar), state);
-    gtk_widget_show_all(GTK_WIDGET(state->window));
-    ds_state->refreshing_list = g_list_append(ds_state->refreshing_list, state);
+  state->timeoutId =
+      g_timeout_add(200, G_SOURCE_FUNC(refresh_progress_bar), state);
+  gtk_widget_show_all(GTK_WIDGET(state->window));
+  ds_state->refreshing_list = g_list_append(ds_state->refreshing_list, state);
 }
 
-void
-handle_close_application_window(gchar *appName,
-                                GVariantIter *extraParams,
-                                DsState  *ds_state)
-{
-    RefreshState *state = NULL;
+void handle_close_application_window(gchar *appName, GVariantIter *extraParams,
+                                     DsState *ds_state) {
+  RefreshState *state = NULL;
 
-    state = find_application(ds_state->refreshing_list, appName);
-    if (state == NULL) {
-        return;
-    }
-    refresh_state_free(state);
+  state = find_application(ds_state->refreshing_list, appName);
+  if (state == NULL) {
+    return;
+  }
+  refresh_state_free(state);
 }
 
-void
-handle_set_pulsed_progress(gchar *appName,
-                           gchar *barText,
-                           GVariantIter *extraParams,
-                           DsState  *ds_state)
-{
-    RefreshState *state = NULL;
+void handle_set_pulsed_progress(gchar *appName, gchar *barText,
+                                GVariantIter *extraParams, DsState *ds_state) {
+  RefreshState *state = NULL;
 
-    state = find_application(ds_state->refreshing_list, appName);
-    if (state == NULL) {
-        return;
-    }
-    state->pulsed = TRUE;
-    if ((barText == NULL) || (barText[0] == 0)) {
-        gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), FALSE);
-    } else {
-        gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
-        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
-    }
-}
-
-void
-handle_set_percentage_progress(gchar *appName,
-                               gchar *barText,
-                               gdouble percent,
-                               GVariantIter *extraParams,
-                               DsState  *ds_state)
-{
-    RefreshState *state = NULL;
-
-    state = find_application(ds_state->refreshing_list, appName);
-    if (state == NULL) {
-        return;
-    }
-    state->pulsed = FALSE;
-    gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(state->progressBar), percent);
+  state = find_application(ds_state->refreshing_list, appName);
+  if (state == NULL) {
+    return;
+  }
+  state->pulsed = TRUE;
+  if ((barText == NULL) || (barText[0] == 0)) {
+    gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), FALSE);
+  } else {
     gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
-    if ((barText != NULL) && (barText[0] == 0)) {
-        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), NULL);
-    } else {
-        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
-    }
+    gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
+  }
 }
 
-RefreshState *
-refresh_state_new(DsState *state,
-                  gchar *appName)
-{
-    RefreshState *object = g_new0(RefreshState, 1);
-    object->appName = g_string_new(appName);
-    object->dsstate = state;
-    object->pulsed = TRUE;
-    return object;
+void handle_set_percentage_progress(gchar *appName, gchar *barText,
+                                    gdouble percent, GVariantIter *extraParams,
+                                    DsState *ds_state) {
+  RefreshState *state = NULL;
+
+  state = find_application(ds_state->refreshing_list, appName);
+  if (state == NULL) {
+    return;
+  }
+  state->pulsed = FALSE;
+  gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(state->progressBar), percent);
+  gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
+  if ((barText != NULL) && (barText[0] == 0)) {
+    gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), NULL);
+  } else {
+    gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
+  }
+}
+
+RefreshState *refresh_state_new(DsState *state, gchar *appName) {
+  RefreshState *object = g_new0(RefreshState, 1);
+  object->appName = g_string_new(appName);
+  object->dsstate = state;
+  object->pulsed = TRUE;
+  return object;
 }
 
 void refresh_state_free(RefreshState *state) {
 
-    DsState *dsstate = state->dsstate;
+  DsState *dsstate = state->dsstate;
 
-    dsstate->refreshing_list = g_list_remove(dsstate->refreshing_list, state);
+  dsstate->refreshing_list = g_list_remove(dsstate->refreshing_list, state);
 
-    if (state->timeoutId != 0) {
-        g_source_remove(state->timeoutId);
-    }
-    if (state->closeId != 0) {
-        g_signal_handler_disconnect(G_OBJECT(state->window), state->closeId);
-    }
-    g_free(state->lockFile);
-    g_clear_object(&state->progressBar);
-    g_string_free(state->appName, TRUE);
-    if (state->window != NULL) {
-        gtk_widget_destroy(GTK_WIDGET(state->window));
-    }
-    g_clear_object(&state->window);
-    g_free(state);
+  if (state->timeoutId != 0) {
+    g_source_remove(state->timeoutId);
+  }
+  if (state->closeId != 0) {
+    g_signal_handler_disconnect(G_OBJECT(state->window), state->closeId);
+  }
+  g_free(state->lockFile);
+  g_clear_object(&state->progressBar);
+  g_string_free(state->appName, TRUE);
+  if (state->window != NULL) {
+    gtk_widget_destroy(GTK_WIDGET(state->window));
+  }
+  g_clear_object(&state->window);
+  g_free(state);
 }

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -23,34 +23,28 @@
 #define _(XX) gettext(XX)
 
 typedef struct {
-    DsState              *dsstate;
-    GString              *appName;
-    GtkApplicationWindow *window;
-    GtkWidget            *progressBar;
-    gchar                *lockFile;
-    guint                 timeoutId;
-    guint                 closeId;
-    gboolean              pulsed;
+  DsState *dsstate;
+  GString *appName;
+  GtkApplicationWindow *window;
+  GtkWidget *progressBar;
+  gchar *lockFile;
+  guint timeoutId;
+  guint closeId;
+  gboolean pulsed;
 } RefreshState;
 
-void handle_application_is_being_refreshed(gchar *appName,
-                                           gchar *lockFilePath,
+void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,
                                            GVariantIter *extraParams,
-                                           DsState  *ds_state);
-void handle_close_application_window(gchar *appName,
-                                     GVariantIter *extraParams,
-                                     DsState  *ds_state);
-void handle_set_pulsed_progress(gchar *appName,
-                                gchar *barText,
-                                GVariantIter *extraParams,
-                                DsState  *ds_state);
-void handle_set_percentage_progress(gchar *appName,
-                                    gchar *barText,
+                                           DsState *ds_state);
+void handle_close_application_window(gchar *appName, GVariantIter *extraParams,
+                                     DsState *ds_state);
+void handle_set_pulsed_progress(gchar *appName, gchar *barText,
+                                GVariantIter *extraParams, DsState *ds_state);
+void handle_set_percentage_progress(gchar *appName, gchar *barText,
                                     gdouble percentage,
                                     GVariantIter *extraParams,
-                                    DsState  *ds_state);
-RefreshState *refresh_state_new(DsState *state,
-                                gchar *appName);
+                                    DsState *ds_state);
+RefreshState *refresh_state_new(DsState *state, gchar *appName);
 
 void refresh_state_free(RefreshState *state);
 


### PR DESCRIPTION
Enforce a code style by formatting using clang-format. This ensures all contributions are in the same style and reduces time to write code (just run clang-format -i after making changes).