### PR TITLE
Add extra options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Example for ApplicationIsBeingRefreshed:
 
     "Firefox","",{"icon":GLib.Variant("s","firefox")}
 
+    "Telegram","",{"icon_image":GLib.Variant("s","/snap/telegram-desktop/4627/meta/gui/icon.png")}
+
 ## Code formatting
 
 Use "clang-format -i SOURCE_FILE_NAME" after any change to automatically

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ and its associated data are:
 * icon_image: the value must be a string variant with the path to a picture. It will show
               that picture to the right of the message. Be careful with the picture size.
 
+### Using d-feet
+
+D-feet can be used to call the methods. To pass the 'extra_data' field, it is required to
+specify the format in the dictionary.
+
+Example for ApplicationIsBeingRefreshed:
+
+    "Firefox","",{"icon":GLib.Variant("s","firefox")}
+
 ## Code formatting
 
 Use "clang-format -i SOURCE_FILE_NAME" after any change to automatically

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
 # snapd-desktop-integration
 User session helpers for snapd
+
+## DBus control
+
+The program has a DBus remote control with the interface
+io.snapcraft.SnapDesktopIntegration, which offers the following methods:
+
+    ApplicationIsBeingRefreshed(identifier:s, control_file_path:s, extra_data:{s:v})
+
+        Shows a new refresh window for the program 'identifier'. If
+        'control_file_path' is empty, the window will be shown until it is
+        destroyed with ApplicationRefreshCompleted(), or by the user by
+        pressing the "Hide" button in the window. But if it points to
+        a file, the window will be destroyed when that file is deleted.
+
+        If there is already a window for that identifier, it will be moved
+        to foreground.
+
+    ApplicationRefreshCompleted(identifier:s, extra_data:{s:v})
+
+        Destroys the refresh window for the program specified in 'identifier'.
+
+    ApplicationRefreshPulsed(identifier:s, bar_text:s, extra_data:{s:v})
+
+        Sets the progress bar to "pulsed mode" for the program 'identifier', and
+        changes the text in the bar to 'bar_text'.
+
+    ApplicationRefreshPercentage(identifier:s, bar_text:s, percentage:d, extra_data:{s:v})
+
+        Sets the progress bar to "percentage mode" for the program 'identifier', and
+        changes the text in the bar to 'bar_text'. The value for the bar is the double
+        passed in 'percentage', and it must be a value between 0 and 1.
+
+### Extra data in calls
+
+All the DBus calls accept a dictionary with extra parameters, called 'extra_data'. This
+dictionary is in the format 'string:variant' for the 'key:value' data. The available keys
+and its associated data are:
+
+* title: the value must be a string variant. It will update the window's title to the
+         specified value.
+
+* message: the value must be a string variant. It will replace the message in the window
+           (which, by default, is "Please wait while...") with the specified value.
+
+* icon: the value must be a string variant containing an icon name. It will show that icon
+        to the right of the message. If the value is an empty string, the icon will be hide.
+
+* icon_image: the value must be a string variant with the path to a picture. It will show
+              that picture to the right of the message. Be careful with the picture size.
+
+## Code formatting
+
+Use "clang-format -i SOURCE_FILE_NAME" after any change to automatically
+format the code.

--- a/data/resources/snap_is_being_refreshed.ui
+++ b/data/resources/snap_is_being_refreshed.ui
@@ -31,26 +31,30 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
+              <object class="GtkImage" id="app_icon">
+                <property name="can-focus">False</property>
+                <property name="margin-start">2</property>
+                <property name="margin-end">2</property>
+                <property name="icon_size">6</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkLabel" id="app_label">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-start">2</property>
+                <property name="margin-end">2</property>
                 <property name="justify">center</property>
                 <property name="xalign">0.5</property>
                 <property name="yalign">0.5</property>
               </object>
               <packing>
                 <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkImage" id="app_icon">
-                <property name="can-focus">False</property>
-                <property name="icon_size">6</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
@@ -105,11 +109,5 @@
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkSizeGroup">
-    <widgets>
-      <widget name="app_icon"/>
-      <widget name="button1"/>
-    </widgets>
   </object>
 </interface>

--- a/data/resources/snap_is_being_refreshed.ui
+++ b/data/resources/snap_is_being_refreshed.ui
@@ -6,6 +6,10 @@
     <property name="width-request">560</property>
     <property name="height-request">200</property>
     <property name="can-focus">False</property>
+    <property name="margin-start">4</property>
+    <property name="margin-end">4</property>
+    <property name="margin-top">4</property>
+    <property name="margin-bottom">4</property>
     <property name="title" translatable="yes">Snap refresh in progress</property>
     <property name="resizable">False</property>
     <property name="deletable">False</property>
@@ -23,16 +27,39 @@
         <property name="orientation">vertical</property>
         <property name="spacing">4</property>
         <child>
-          <object class="GtkLabel" id="app_label">
+          <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="justify">center</property>
-            <property name="xalign">0.5</property>
-            <property name="yalign">0.5</property>
+            <child>
+              <object class="GtkLabel" id="app_label">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="justify">center</property>
+                <property name="xalign">0.5</property>
+                <property name="yalign">0.5</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage" id="app_icon">
+                <property name="can-focus">False</property>
+                <property name="icon_size">6</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="padding">2</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -45,16 +72,16 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="valign">center</property>
+                <property name="margin-end">4</property>
               </object>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="padding">4</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="button1">
                 <property name="label" translatable="yes">Hide</property>
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
@@ -65,7 +92,6 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="padding">4</property>
                 <property name="position">1</property>
               </packing>
             </child>
@@ -73,10 +99,17 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <property name="padding">2</property>
             <property name="position">1</property>
           </packing>
         </child>
       </object>
     </child>
+  </object>
+  <object class="GtkSizeGroup">
+    <widgets>
+      <widget name="app_icon"/>
+      <widget name="button1"/>
+    </widgets>
   </object>
 </interface>

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('snapd-desktop-integration', 'c', version: '0.1')
+project('snapd-desktop-integration', 'c', version: '0.9')
 
 gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0')

--- a/po/es.po
+++ b/po/es.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: snapd-desktop-integration\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-16 11:33+0100\n"
-"PO-Revision-Date: 2023-03-16 16:30+0100\n"
+"POT-Creation-Date: 2023-03-30 12:55+0200\n"
+"PO-Revision-Date: 2023-03-30 12:56+0200\n"
 "Last-Translator: Sergio Costas <sergio.costas@canonical.com>\n"
 "Language-Team: Spanish - Spain <sergio.costas@canonical.com>\n"
 "Language: es_ES\n"
@@ -19,10 +19,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "X-Generator: Gtranslator 42.0\n"
 
-#: src/refresh_status.c:103
+#: src/refresh_status.c:186
 #, c-format
-msgid "Please wait while “%s” is being refreshed to the latest version."
-msgstr "Por favor, espere mientras “%s” se refresca a la última versión."
+msgid "Refreshing “%s” to latest version. Please wait."
+msgstr "Actualizando “%s” a la última versión. Espere, por favor."
 
 #: src/main.c:68 src/main.c:85 src/main.c:106
 msgid "Installing missing theme snaps:"
@@ -63,10 +63,14 @@ msgstr "Sí"
 msgid "No"
 msgstr "No"
 
-#: data/resources/snap_is_being_refreshed.ui:9
+#: data/resources/snap_is_being_refreshed.ui:13
 msgid "Snap refresh in progress"
-msgstr "Refrescando Snap"
+msgstr "Actualizando Snap"
 
-#: data/resources/snap_is_being_refreshed.ui:58
+#: data/resources/snap_is_being_refreshed.ui:89
 msgid "Hide"
 msgstr "Ocultar"
+
+#, c-format
+#~ msgid "Please wait while “%s” is being refreshed to the latest version."
+#~ msgstr "Por favor, espere mientras “%s” se refresca a la última versión."

--- a/po/es.po
+++ b/po/es.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: snapd-desktop-integration\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-16 11:33+0100\n"
-"PO-Revision-Date: 2023-03-16 11:34+0100\n"
+"PO-Revision-Date: 2023-03-16 16:30+0100\n"
 "Last-Translator: Sergio Costas <sergio.costas@canonical.com>\n"
 "Language-Team: Spanish - Spain <sergio.costas@canonical.com>\n"
 "Language: es_ES\n"
@@ -22,7 +22,7 @@ msgstr ""
 #: src/refresh_status.c:103
 #, c-format
 msgid "Please wait while “%s” is being refreshed to the latest version."
-msgstr "Por favor, espere mientras '%s' se refresca a la última versión."
+msgstr "Por favor, espere mientras “%s” se refresca a la última versión."
 
 #: src/main.c:68 src/main.c:85 src/main.c:106
 msgid "Installing missing theme snaps:"

--- a/po/oc.po
+++ b/po/oc.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: snapd-desktop-integration\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-16 11:33+0100\n"
+"POT-Creation-Date: 2023-03-30 12:55+0200\n"
 "PO-Revision-Date: 2023-02-28 14:51+0100\n"
 "Last-Translator: Quentin PAGÈS\n"
 "Language-Team: \n"
@@ -17,9 +17,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: src/refresh_status.c:103
+#: src/refresh_status.c:186
 #, c-format
-msgid "Please wait while “%s” is being refreshed to the latest version."
+msgid "Refreshing “%s” to latest version. Please wait."
 msgstr ""
 
 #: src/main.c:68 src/main.c:85 src/main.c:106
@@ -61,10 +61,10 @@ msgstr "Òc"
 msgid "No"
 msgstr ""
 
-#: data/resources/snap_is_being_refreshed.ui:9
+#: data/resources/snap_is_being_refreshed.ui:13
 msgid "Snap refresh in progress"
 msgstr "Actualizacion de Snap en cors"
 
-#: data/resources/snap_is_being_refreshed.ui:58
+#: data/resources/snap_is_being_refreshed.ui:89
 msgid "Hide"
 msgstr "Amagar"

--- a/po/snapd-desktop-integration.pot
+++ b/po/snapd-desktop-integration.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: snapd-desktop-integration\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-16 11:33+0100\n"
+"POT-Creation-Date: 2023-03-30 12:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,9 +17,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/refresh_status.c:103
+#: src/refresh_status.c:186
 #, c-format
-msgid "Please wait while “%s” is being refreshed to the latest version."
+msgid "Refreshing “%s” to latest version. Please wait."
 msgstr ""
 
 #: src/main.c:68 src/main.c:85 src/main.c:106
@@ -61,10 +61,10 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: data/resources/snap_is_being_refreshed.ui:9
+#: data/resources/snap_is_being_refreshed.ui:13
 msgid "Snap refresh in progress"
 msgstr ""
 
-#: data/resources/snap_is_being_refreshed.ui:58
+#: data/resources/snap_is_being_refreshed.ui:89
 msgid "Hide"
 msgstr ""

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,12 +14,6 @@ layout:
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
 
-plugs:
-  read-snap-data:
-    interface: system-files
-    read:
-      - /snap
-
 apps:
   snapd-desktop-integration:
     extensions: [gnome]
@@ -32,7 +26,7 @@ apps:
     plugs:
       - snap-themes-control
       - login-session-observe
-      - read-snap-data
+      - desktop-launch
 
 slots:
   snapd-desktop-integration:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,12 @@ layout:
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
 
+plugs:
+  read-snap-data:
+    interface: system-files
+    read:
+      - /snap
+
 apps:
   snapd-desktop-integration:
     extensions: [gnome]
@@ -26,6 +32,7 @@ apps:
     plugs:
       - snap-themes-control
       - login-session-observe
+      - read-snap-data
 
 slots:
   snapd-desktop-integration:

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -53,8 +53,8 @@ static gboolean dbus_handle_set_pulsed_progress(
 
 static gboolean dbus_handle_set_percentage_progress(
     SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
-    gchar *snapName, gchar *barText, gdouble percentage,
-    GVariant *extraParams, gpointer data) {
+    gchar *snapName, gchar *barText, gdouble percentage, GVariant *extraParams,
+    gpointer data) {
 
   handle_set_percentage_progress(snapName, barText, percentage, extraParams,
                                  data);

--- a/src/dbus.c
+++ b/src/dbus.c
@@ -21,7 +21,7 @@
 
 static gboolean dbus_handle_application_is_being_refreshed(
     SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
-    gchar *snapName, gchar *lockFilePath, GVariantIter *extraParams,
+    gchar *snapName, gchar *lockFilePath, GVariant *extraParams,
     gpointer data) {
 
   handle_application_is_being_refreshed(snapName, lockFilePath, extraParams,
@@ -33,7 +33,7 @@ static gboolean dbus_handle_application_is_being_refreshed(
 
 static gboolean dbus_handle_close_application_window(
     SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
-    gchar *snapName, GVariantIter *extraParams, gpointer data) {
+    gchar *snapName, GVariant *extraParams, gpointer data) {
 
   handle_close_application_window(snapName, extraParams, data);
   snap_desktop_integration_complete_application_refresh_completed(skeleton,
@@ -43,7 +43,7 @@ static gboolean dbus_handle_close_application_window(
 
 static gboolean dbus_handle_set_pulsed_progress(
     SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
-    gchar *snapName, gchar *barText, GVariantIter *extraParams, gpointer data) {
+    gchar *snapName, gchar *barText, GVariant *extraParams, gpointer data) {
 
   handle_set_pulsed_progress(snapName, barText, extraParams, data);
   snap_desktop_integration_complete_application_refresh_pulsed(skeleton,
@@ -54,7 +54,7 @@ static gboolean dbus_handle_set_pulsed_progress(
 static gboolean dbus_handle_set_percentage_progress(
     SnapDesktopIntegration *skeleton, GDBusMethodInvocation *invocation,
     gchar *snapName, gchar *barText, gdouble percentage,
-    GVariantIter *extraParams, gpointer data) {
+    GVariant *extraParams, gpointer data) {
 
   handle_set_percentage_progress(snapName, barText, percentage, extraParams,
                                  data);

--- a/src/ds_state.h
+++ b/src/ds_state.h
@@ -23,7 +23,7 @@
 #include <libnotify/notify.h>
 #include <snapd-glib/snapd-glib.h>
 
-#define ICON_SIZE 64
+#define ICON_SIZE 48
 
 typedef struct {
   SnapDesktopIntegration *skeleton;

--- a/src/ds_state.h
+++ b/src/ds_state.h
@@ -23,6 +23,8 @@
 #include <libnotify/notify.h>
 #include <snapd-glib/snapd-glib.h>
 
+#define ICON_SIZE 64
+
 typedef struct {
   SnapDesktopIntegration *skeleton;
 

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -182,9 +182,8 @@ void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,
   state->icon =
       GTK_WIDGET(g_object_ref(gtk_builder_get_object(builder, "app_icon")));
   labelText = g_string_new("");
-  g_string_printf(labelText,
-                  _("Refreshing “%s” to latest version. Please wait."),
-                  appName);
+  g_string_printf(
+      labelText, _("Refreshing “%s” to latest version. Please wait."), appName);
   gtk_label_set_text(state->message, labelText->str);
 
   state->timeoutId =

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -183,8 +183,7 @@ void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,
       GTK_WIDGET(g_object_ref(gtk_builder_get_object(builder, "app_icon")));
   labelText = g_string_new("");
   g_string_printf(labelText,
-                  _("Please wait while “%s” is being refreshed to the latest "
-                    "version."),
+                  _("Refreshing “%s” to latest version. Please wait."),
                   appName);
   gtk_label_set_text(state->message, labelText->str);
 

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -99,8 +99,7 @@ static void set_icon_image(RefreshState *state, const gchar *path) {
   gtk_image_set_from_file(GTK_IMAGE(state->icon), path);
 }
 
-static void handle_extra_params(RefreshState *state,
-                                GVariant *extraParams) {
+static void handle_extra_params(RefreshState *state, GVariant *extraParams) {
   GVariantIter iter;
   GVariant *value;
   gchar *key;

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -27,6 +27,8 @@ typedef struct {
   GString *appName;
   GtkApplicationWindow *window;
   GtkWidget *progressBar;
+  GtkLabel *message;
+  GtkWidget *icon;
   gchar *lockFile;
   guint timeoutId;
   guint closeId;
@@ -34,15 +36,15 @@ typedef struct {
 } RefreshState;
 
 void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,
-                                           GVariantIter *extraParams,
+                                           GVariant *extraParams,
                                            DsState *ds_state);
-void handle_close_application_window(gchar *appName, GVariantIter *extraParams,
+void handle_close_application_window(gchar *appName, GVariant *extraParams,
                                      DsState *ds_state);
 void handle_set_pulsed_progress(gchar *appName, gchar *barText,
-                                GVariantIter *extraParams, DsState *ds_state);
+                                GVariant *extraParams, DsState *ds_state);
 void handle_set_percentage_progress(gchar *appName, gchar *barText,
                                     gdouble percentage,
-                                    GVariantIter *extraParams,
+                                    GVariant *extraParams,
                                     DsState *ds_state);
 RefreshState *refresh_state_new(DsState *state, gchar *appName);
 

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -43,8 +43,7 @@ void handle_close_application_window(gchar *appName, GVariant *extraParams,
 void handle_set_pulsed_progress(gchar *appName, gchar *barText,
                                 GVariant *extraParams, DsState *ds_state);
 void handle_set_percentage_progress(gchar *appName, gchar *barText,
-                                    gdouble percentage,
-                                    GVariant *extraParams,
+                                    gdouble percentage, GVariant *extraParams,
                                     DsState *ds_state);
 RefreshState *refresh_state_new(DsState *state, gchar *appName);
 


### PR DESCRIPTION
Allows to specify several extra options in the "extra_data" field in each DBus call. These options allow to set an icon, change the window's title, or the message.

![image](https://user-images.githubusercontent.com/105285003/225684958-9482018a-bba8-4d13-806e-e913237e5f3c.png)

In order to get access to any SNAP icon, it requires a "system-files" interface and permissions, which, for the snap store, requires specific permissions https://snapcraft.io/docs/system-files-interface