### PR TITLE
Use system-files interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,12 @@ layout:
   /usr/share/locale:
     bind: $SNAP/usr/share/locale
 
+plugs:
+  read-snap-data:
+    interface: system-files
+    read:
+      - /snap
+
 apps:
   snapd-desktop-integration:
     extensions: [gnome]
@@ -26,7 +32,7 @@ apps:
     plugs:
       - snap-themes-control
       - login-session-observe
-      - desktop-launch
+      - read-snap-data
 
 slots:
   snapd-desktop-integration:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ layout:
     bind: $SNAP/usr/share/locale
 
 plugs:
-  read-snap-data:
+  read-snap:
     interface: system-files
     read:
       - /snap
@@ -32,7 +32,7 @@ apps:
     plugs:
       - snap-themes-control
       - login-session-observe
-      - read-snap-data
+      - read-snap
 
 slots:
   snapd-desktop-integration:


### PR DESCRIPTION
Replace the launch interface with the system-files one, as requested.