### PR TITLE
Make the window bigger if needed, but not smaller

### DIFF
--- a/data/resources/snap_is_being_refreshed.ui
+++ b/data/resources/snap_is_being_refreshed.ui
@@ -15,6 +15,7 @@
     <property name="deletable">False</property>
     <property name="show-menubar">False</property>
     <signal name="delete-event" handler="on_delete_window" swapped="no"/>
+    <signal name="size-allocate" handler="on_main_window_size_allocate" swapped="no"/>
     <child>
       <object class="GtkBox">
         <property name="width-request">540</property>

--- a/src/refresh_status.c
+++ b/src/refresh_status.c
@@ -35,6 +35,23 @@ void on_hide_clicked(GtkButton *button, RefreshState *state) {
   refresh_state_free(state);
 }
 
+void on_main_window_size_allocate(GtkApplicationWindow *self,
+                                  GtkAllocation *allocation,
+                                  RefreshState *state) {
+  gboolean modified = FALSE;
+  if (allocation->width > state->width) {
+    modified = TRUE;
+    state->width = allocation->width;
+  }
+  if (allocation->height > state->height) {
+    modified = TRUE;
+    state->height = allocation->height;
+  }
+  if (modified) {
+    gtk_widget_set_size_request(GTK_WIDGET(self), state->width, state->height);
+  }
+}
+
 static gboolean refresh_progress_bar(RefreshState *state) {
   struct stat statbuf;
   if (state->pulsed) {
@@ -258,6 +275,8 @@ RefreshState *refresh_state_new(DsState *state, gchar *appName) {
   object->appName = g_string_new(appName);
   object->dsstate = state;
   object->pulsed = TRUE;
+  object->width = 0;
+  object->height = 0;
   return object;
 }
 

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -34,6 +34,8 @@ typedef struct {
   guint closeId;
   gboolean pulsed;
   gboolean wait_change_in_lock_file;
+  gint width;
+  gint height;
 } RefreshState;
 
 void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,


### PR DESCRIPTION
This MR makes the window bigger if the text requires more space, but once it has grown, it will keep the new size, no matter if new texts are smaller. This avoids the ugly effect of a window increasing and decreasing its size.