### PR TITLE
Allow to wait for a change in lock file

### DIFF
--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -33,6 +33,7 @@ typedef struct {
   guint timeoutId;
   guint closeId;
   gboolean pulsed;
+  gboolean wait_change_in_lock_file;
 } RefreshState;
 
 void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,


### PR DESCRIPTION
It adds a new option to wait for the lock file to be locked, and only then close the dialog when the file is unlocked.