### PR TITLE
Add support for using the DBus API

### DIFF
--- a/data/io.snapcraft.SnapChanges.dbus.xml
+++ b/data/io.snapcraft.SnapChanges.dbus.xml
@@ -8,7 +8,6 @@
 	<signal name="Change">
 		<arg type="s" name="change_id" />
 		<arg type="s" name="change_type" />
-		<arg type="s" name="change_kind" />
 		<arg type="a{sv}" name="metadata" />
 	</signal>
 </interface>

--- a/data/io.snapcraft.SnapChanges.dbus.xml
+++ b/data/io.snapcraft.SnapChanges.dbus.xml
@@ -1,0 +1,15 @@
+<node>
+<interface name='io.snapcraft.SnapChanges'>
+	<method name="GetTasks">
+		<arg type="s" name="change_id" direction="in" />
+		<arg type="a{sv}" name="extra_data" direction="in" />
+		<arg type="a{sa{sv}}" name="tasks_data" direction="out" />
+	</method>
+	<signal name="Change">
+		<arg type="s" name="change_id" />
+		<arg type="s" name="change_type" />
+		<arg type="s" name="change_kind" />
+		<arg type="a{sv}" name="metadata" />
+	</signal>
+</interface>
+</node>

--- a/data/meson.build
+++ b/data/meson.build
@@ -18,3 +18,9 @@ gdbus_src = gnome.gdbus_codegen('io.snapcraft.SnapDesktopIntegration',
   interface_prefix : 'io.snapcraft.',
   docbook : 'SnapDesktopIntegration-interface-doc'
 )
+
+snap_changes_src = gnome.gdbus_codegen('io.snapcraft.SnapChanges',
+  sources: 'io.snapcraft.SnapChanges.dbus.xml',
+  interface_prefix : 'io.snapcraft.',
+  docbook : 'SnapChanges-interface-doc'
+)

--- a/src/changes.c
+++ b/src/changes.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "io.snapcraft.SnapChanges.h"
+#include "refresh_status.h"
+#include "changes.h"
+
+static void destroy_snap_progress(SnapProgress *data) {
+    g_free(data->change_id);
+    if (data->timeout_id != 0) {
+        g_source_remove(data->timeout_id);
+        data->timeout_id = 0;
+    }
+    g_free(data);
+}
+
+static void init_all_status(DsState *ds_state) {
+    GList *list = ds_state->refreshing_list;
+    for (; list != NULL; list = list->next) {
+        RefreshState *state = (RefreshState *)list->data;
+        state->ntasks = 0;
+        state->doneTasks = 0;
+        state->minId = G_MAXUINT;
+        state->updated = FALSE;
+    }
+}
+
+static void update_task(GVariant *task_value, SnapProgress *data) {
+    GVariantIter entry_iter;
+    GVariant *entry, *entry_key, *entry_container, *entry_value;
+    g_autofree const gchar *instance_name = NULL;
+    g_autofree const gchar *summary = NULL;
+    g_autofree const gchar *status = NULL;
+    guint task_id = G_MAXUINT;
+    RefreshState *refresh_state;
+
+    // process task
+    g_variant_iter_init(&entry_iter, task_value);
+    task_id = G_MAXUINT;
+    while ((entry = g_variant_iter_next_value(&entry_iter)) != NULL) {
+        entry_key = g_variant_get_child_value(entry, 0);
+        entry_container = g_variant_get_child_value(entry, 1);
+        entry_value = g_variant_get_child_value(entry_container, 0);
+        if ((entry_key != NULL) && (entry_value != NULL)) {
+            if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "ID")) {
+                task_id = atoi(g_variant_get_string(entry_value, NULL));
+            } else if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "Status")) {
+                status = g_strdup(g_variant_get_string(entry_value, NULL));
+            } else if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "SnapName")) {
+                instance_name = g_strdup(g_variant_get_string(entry_value, NULL));
+            } else if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "Summary")) {
+                summary = g_strdup(g_variant_get_string(entry_value, NULL));
+            }
+        }
+        g_variant_unref(entry_key);
+        g_variant_unref(entry_container);
+        g_variant_unref(entry_value);
+    }
+
+    if ((instance_name == NULL) || (instance_name[0] == 0)) {
+        return;
+    }
+
+    refresh_state = ds_state_find_application(data->state, instance_name);
+    if (refresh_state == NULL) {
+        handle_application_is_being_refreshed((gchar *)instance_name, "", NULL, data->state);
+        refresh_state = ds_state_find_application(data->state, instance_name);
+    }
+    refresh_state->updated = TRUE;
+    refresh_state->ntasks++;
+    if ((0 != g_strcmp0(status, "Doing")) && (0 != g_strcmp0(status, "Do"))) {
+        refresh_state->doneTasks++;
+    }
+    if ((task_id < refresh_state->minId) && (summary != NULL)) {
+        refresh_state->minId = task_id;
+        g_free(refresh_state->summary);
+        refresh_state->summary = g_strdup(summary);
+    }
+}
+
+static gboolean update_refresh_notifications(SnapProgress *data) {
+    GList *list = data->state->refreshing_list;
+    gchar *barText;
+    gboolean allDone = TRUE;
+    for (; list != NULL; list = list->next) {
+        RefreshState *state = (RefreshState *)list->data;
+        if (state->updated) {
+            if (state->ntasks == state->doneTasks) {
+                handle_close_application_window(state->appName->str, NULL, data->state);
+                return TRUE;
+            } else {
+                allDone = FALSE;
+                state->pulsed = FALSE;
+                gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(state->progressBar), ((gfloat)state->doneTasks) / ((gfloat)state->ntasks));
+                gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
+                barText = g_strdup_printf("%s (%d/%d)", state->summary, state->doneTasks, state->ntasks);
+                gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
+                g_free(barText);
+                g_free(state->summary);
+                state->summary = NULL;
+            }
+        }
+    }
+    if (allDone) {
+        destroy_snap_progress(data);
+    }
+    return FALSE;
+}
+
+static void receive_tasks(SnapChanges *proxy, GAsyncResult *res, SnapProgress *data) {
+    g_autoptr(GVariant) tasks = NULL;
+    GVariant *task, *task_value;
+    GVariantIter task_iter;
+
+    data->busy = FALSE;
+    if (!snap_changes_call_get_tasks_finish (proxy, &tasks, res, NULL)) {
+        return;
+    }
+
+    init_all_status(data->state);
+
+    g_variant_iter_init(&task_iter, tasks);
+    while ((task = g_variant_iter_next_value(&task_iter)) != NULL) {
+        task_value = g_variant_get_child_value(task, 1);
+        if (task_value == NULL) {
+            continue;
+        }
+        update_task(task_value, data);
+        g_variant_unref(task_value);
+        g_variant_unref(task);
+    }
+    while (update_refresh_notifications(data)) {}
+}
+
+static gboolean launch_progress_cb(SnapProgress *data) {
+    g_autoptr (GVariantType) extra_data_type = g_variant_type_new("{sv}");
+    if (data->busy) {
+        return TRUE;
+    }
+    data->busy = TRUE;
+    snap_changes_call_get_tasks (data->state->snap_dbus_proxy,
+                                 data->change_id,
+                                 g_variant_new_array(extra_data_type, NULL, 0),
+                                 NULL,
+                                 (GAsyncReadyCallback) receive_tasks,
+                                 data);
+    return TRUE;
+}
+
+static void launch_progress_bar(const gchar *change_id, DsState *state) {
+    SnapProgress *data = g_new0(SnapProgress, 1);
+    data->state = state;
+    data->change_id = g_strdup(change_id);
+    data->busy = FALSE;
+    data->timeout_id = g_timeout_add(CHANGE_CHECK_INTERVAL, (GSourceFunc)launch_progress_cb, data);
+}
+
+static void snap_dbus_handle_change (SnapChanges *object,
+                                     const gchar *arg_change_id,
+                                     const gchar *arg_change_type,
+                                     const gchar *arg_change_kind,
+                                     GVariant *arg_metadata,
+                                     DsState *state) {
+    if (g_strcmp0(arg_change_type, "delayed-auto-refresh") == 0) {
+        launch_progress_bar(arg_change_id, state);
+    }
+}
+
+void snap_dbus_cb(GDBusConnection *connection, GAsyncResult *res, DsState *state) {
+    state->snap_dbus_proxy = snap_changes_proxy_new_finish (res, NULL);
+    if (state->snap_dbus_proxy == NULL) {
+        g_warning("Failed to connect to the snap userd agent DBus interface");
+        return;
+    }
+    g_signal_connect(state->snap_dbus_proxy, "change",
+                     G_CALLBACK(snap_dbus_handle_change),
+                     state);
+}
+
+void manage_snap_dbus(GDBusConnection *connection, DsState *state) {
+
+    snap_changes_proxy_new (connection,
+                            G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                            "io.snapcraft.SessionAgent",
+                            "/io/snapcraft/SnapChanges",
+                            NULL,
+                            (GAsyncReadyCallback) snap_dbus_cb,
+                            state);
+
+}

--- a/src/changes.c
+++ b/src/changes.c
@@ -181,7 +181,6 @@ static void launch_progress_bar(const gchar *change_id, DsState *state) {
 static void snap_dbus_handle_change(SnapChanges *object,
                                     const gchar *arg_change_id,
                                     const gchar *arg_change_type,
-                                    const gchar *arg_change_kind,
                                     GVariant *arg_metadata, DsState *state) {
   if (g_strcmp0(arg_change_type, "delayed-auto-refresh") == 0) {
     launch_progress_bar(arg_change_id, state);

--- a/src/changes.c
+++ b/src/changes.c
@@ -15,190 +15,194 @@
  *
  */
 
+#include "changes.h"
 #include "io.snapcraft.SnapChanges.h"
 #include "refresh_status.h"
-#include "changes.h"
 
 static void destroy_snap_progress(SnapProgress *data) {
-    g_free(data->change_id);
-    if (data->timeout_id != 0) {
-        g_source_remove(data->timeout_id);
-        data->timeout_id = 0;
-    }
-    g_free(data);
+  g_free(data->change_id);
+  if (data->timeout_id != 0) {
+    g_source_remove(data->timeout_id);
+    data->timeout_id = 0;
+  }
+  g_free(data);
 }
 
 static void init_all_status(DsState *ds_state) {
-    GList *list = ds_state->refreshing_list;
-    for (; list != NULL; list = list->next) {
-        RefreshState *state = (RefreshState *)list->data;
-        state->ntasks = 0;
-        state->doneTasks = 0;
-        state->minId = G_MAXUINT;
-        state->updated = FALSE;
-    }
+  GList *list = ds_state->refreshing_list;
+  for (; list != NULL; list = list->next) {
+    RefreshState *state = (RefreshState *)list->data;
+    state->ntasks = 0;
+    state->doneTasks = 0;
+    state->minId = G_MAXUINT;
+    state->updated = FALSE;
+  }
 }
 
 static void update_task(GVariant *task_value, SnapProgress *data) {
-    GVariantIter entry_iter;
-    GVariant *entry, *entry_key, *entry_container, *entry_value;
-    g_autofree const gchar *instance_name = NULL;
-    g_autofree const gchar *summary = NULL;
-    g_autofree const gchar *status = NULL;
-    guint task_id = G_MAXUINT;
-    RefreshState *refresh_state;
+  GVariantIter entry_iter;
+  GVariant *entry, *entry_key, *entry_container, *entry_value;
+  g_autofree const gchar *instance_name = NULL;
+  g_autofree const gchar *summary = NULL;
+  g_autofree const gchar *status = NULL;
+  guint task_id = G_MAXUINT;
+  RefreshState *refresh_state;
 
-    // process task
-    g_variant_iter_init(&entry_iter, task_value);
-    task_id = G_MAXUINT;
-    while ((entry = g_variant_iter_next_value(&entry_iter)) != NULL) {
-        entry_key = g_variant_get_child_value(entry, 0);
-        entry_container = g_variant_get_child_value(entry, 1);
-        entry_value = g_variant_get_child_value(entry_container, 0);
-        if ((entry_key != NULL) && (entry_value != NULL)) {
-            if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "ID")) {
-                task_id = atoi(g_variant_get_string(entry_value, NULL));
-            } else if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "Status")) {
-                status = g_strdup(g_variant_get_string(entry_value, NULL));
-            } else if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "SnapName")) {
-                instance_name = g_strdup(g_variant_get_string(entry_value, NULL));
-            } else if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "Summary")) {
-                summary = g_strdup(g_variant_get_string(entry_value, NULL));
-            }
-        }
-        g_variant_unref(entry_key);
-        g_variant_unref(entry_container);
-        g_variant_unref(entry_value);
+  // process task
+  g_variant_iter_init(&entry_iter, task_value);
+  task_id = G_MAXUINT;
+  while ((entry = g_variant_iter_next_value(&entry_iter)) != NULL) {
+    entry_key = g_variant_get_child_value(entry, 0);
+    entry_container = g_variant_get_child_value(entry, 1);
+    entry_value = g_variant_get_child_value(entry_container, 0);
+    if ((entry_key != NULL) && (entry_value != NULL)) {
+      if (0 == g_strcmp0(g_variant_get_string(entry_key, NULL), "ID")) {
+        task_id = atoi(g_variant_get_string(entry_value, NULL));
+      } else if (0 ==
+                 g_strcmp0(g_variant_get_string(entry_key, NULL), "Status")) {
+        status = g_strdup(g_variant_get_string(entry_value, NULL));
+      } else if (0 ==
+                 g_strcmp0(g_variant_get_string(entry_key, NULL), "SnapName")) {
+        instance_name = g_strdup(g_variant_get_string(entry_value, NULL));
+      } else if (0 ==
+                 g_strcmp0(g_variant_get_string(entry_key, NULL), "Summary")) {
+        summary = g_strdup(g_variant_get_string(entry_value, NULL));
+      }
     }
+    g_variant_unref(entry_key);
+    g_variant_unref(entry_container);
+    g_variant_unref(entry_value);
+  }
 
-    if ((instance_name == NULL) || (instance_name[0] == 0)) {
-        return;
-    }
+  if ((instance_name == NULL) || (instance_name[0] == 0)) {
+    return;
+  }
 
+  refresh_state = ds_state_find_application(data->state, instance_name);
+  if (refresh_state == NULL) {
+    handle_application_is_being_refreshed((gchar *)instance_name, "", NULL,
+                                          data->state);
     refresh_state = ds_state_find_application(data->state, instance_name);
-    if (refresh_state == NULL) {
-        handle_application_is_being_refreshed((gchar *)instance_name, "", NULL, data->state);
-        refresh_state = ds_state_find_application(data->state, instance_name);
-    }
-    refresh_state->updated = TRUE;
-    refresh_state->ntasks++;
-    if ((0 != g_strcmp0(status, "Doing")) && (0 != g_strcmp0(status, "Do"))) {
-        refresh_state->doneTasks++;
-    }
-    if ((task_id < refresh_state->minId) && (summary != NULL)) {
-        refresh_state->minId = task_id;
-        g_free(refresh_state->summary);
-        refresh_state->summary = g_strdup(summary);
-    }
+  }
+  refresh_state->updated = TRUE;
+  refresh_state->ntasks++;
+  if ((0 != g_strcmp0(status, "Doing")) && (0 != g_strcmp0(status, "Do"))) {
+    refresh_state->doneTasks++;
+  }
+  if ((task_id < refresh_state->minId) && (summary != NULL)) {
+    refresh_state->minId = task_id;
+    g_free(refresh_state->summary);
+    refresh_state->summary = g_strdup(summary);
+  }
 }
 
 static gboolean update_refresh_notifications(SnapProgress *data) {
-    GList *list = data->state->refreshing_list;
-    gchar *barText;
-    gboolean allDone = TRUE;
-    for (; list != NULL; list = list->next) {
-        RefreshState *state = (RefreshState *)list->data;
-        if (state->updated) {
-            if (state->ntasks == state->doneTasks) {
-                handle_close_application_window(state->appName->str, NULL, data->state);
-                return TRUE;
-            } else {
-                allDone = FALSE;
-                state->pulsed = FALSE;
-                gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(state->progressBar), ((gfloat)state->doneTasks) / ((gfloat)state->ntasks));
-                gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar), TRUE);
-                barText = g_strdup_printf("%s (%d/%d)", state->summary, state->doneTasks, state->ntasks);
-                gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar), barText);
-                g_free(barText);
-                g_free(state->summary);
-                state->summary = NULL;
-            }
-        }
+  GList *list = data->state->refreshing_list;
+  gchar *barText;
+  gboolean allDone = TRUE;
+  for (; list != NULL; list = list->next) {
+    RefreshState *state = (RefreshState *)list->data;
+    if (state->updated) {
+      if (state->ntasks == state->doneTasks) {
+        handle_close_application_window(state->appName->str, NULL, data->state);
+        return TRUE;
+      } else {
+        allDone = FALSE;
+        state->pulsed = FALSE;
+        gtk_progress_bar_set_fraction(GTK_PROGRESS_BAR(state->progressBar),
+                                      ((gfloat)state->doneTasks) /
+                                          ((gfloat)state->ntasks));
+        gtk_progress_bar_set_show_text(GTK_PROGRESS_BAR(state->progressBar),
+                                       TRUE);
+        barText = g_strdup_printf("%s (%d/%d)", state->summary,
+                                  state->doneTasks, state->ntasks);
+        gtk_progress_bar_set_text(GTK_PROGRESS_BAR(state->progressBar),
+                                  barText);
+        g_free(barText);
+        g_free(state->summary);
+        state->summary = NULL;
+      }
     }
-    if (allDone) {
-        destroy_snap_progress(data);
-    }
-    return FALSE;
+  }
+  if (allDone) {
+    destroy_snap_progress(data);
+  }
+  return FALSE;
 }
 
-static void receive_tasks(SnapChanges *proxy, GAsyncResult *res, SnapProgress *data) {
-    g_autoptr(GVariant) tasks = NULL;
-    GVariant *task, *task_value;
-    GVariantIter task_iter;
+static void receive_tasks(SnapChanges *proxy, GAsyncResult *res,
+                          SnapProgress *data) {
+  g_autoptr(GVariant) tasks = NULL;
+  GVariant *task, *task_value;
+  GVariantIter task_iter;
 
-    data->busy = FALSE;
-    if (!snap_changes_call_get_tasks_finish (proxy, &tasks, res, NULL)) {
-        return;
+  data->busy = FALSE;
+  if (!snap_changes_call_get_tasks_finish(proxy, &tasks, res, NULL)) {
+    return;
+  }
+
+  init_all_status(data->state);
+
+  g_variant_iter_init(&task_iter, tasks);
+  while ((task = g_variant_iter_next_value(&task_iter)) != NULL) {
+    task_value = g_variant_get_child_value(task, 1);
+    if (task_value == NULL) {
+      continue;
     }
-
-    init_all_status(data->state);
-
-    g_variant_iter_init(&task_iter, tasks);
-    while ((task = g_variant_iter_next_value(&task_iter)) != NULL) {
-        task_value = g_variant_get_child_value(task, 1);
-        if (task_value == NULL) {
-            continue;
-        }
-        update_task(task_value, data);
-        g_variant_unref(task_value);
-        g_variant_unref(task);
-    }
-    while (update_refresh_notifications(data)) {}
+    update_task(task_value, data);
+    g_variant_unref(task_value);
+    g_variant_unref(task);
+  }
+  while (update_refresh_notifications(data)) {
+  }
 }
 
 static gboolean launch_progress_cb(SnapProgress *data) {
-    g_autoptr (GVariantType) extra_data_type = g_variant_type_new("{sv}");
-    if (data->busy) {
-        return TRUE;
-    }
-    data->busy = TRUE;
-    snap_changes_call_get_tasks (data->state->snap_dbus_proxy,
-                                 data->change_id,
-                                 g_variant_new_array(extra_data_type, NULL, 0),
-                                 NULL,
-                                 (GAsyncReadyCallback) receive_tasks,
-                                 data);
+  g_autoptr(GVariantType) extra_data_type = g_variant_type_new("{sv}");
+  if (data->busy) {
     return TRUE;
+  }
+  data->busy = TRUE;
+  snap_changes_call_get_tasks(data->state->snap_dbus_proxy, data->change_id,
+                              g_variant_new_array(extra_data_type, NULL, 0),
+                              NULL, (GAsyncReadyCallback)receive_tasks, data);
+  return TRUE;
 }
 
 static void launch_progress_bar(const gchar *change_id, DsState *state) {
-    SnapProgress *data = g_new0(SnapProgress, 1);
-    data->state = state;
-    data->change_id = g_strdup(change_id);
-    data->busy = FALSE;
-    data->timeout_id = g_timeout_add(CHANGE_CHECK_INTERVAL, (GSourceFunc)launch_progress_cb, data);
+  SnapProgress *data = g_new0(SnapProgress, 1);
+  data->state = state;
+  data->change_id = g_strdup(change_id);
+  data->busy = FALSE;
+  data->timeout_id = g_timeout_add(CHANGE_CHECK_INTERVAL,
+                                   (GSourceFunc)launch_progress_cb, data);
 }
 
-static void snap_dbus_handle_change (SnapChanges *object,
-                                     const gchar *arg_change_id,
-                                     const gchar *arg_change_type,
-                                     const gchar *arg_change_kind,
-                                     GVariant *arg_metadata,
-                                     DsState *state) {
-    if (g_strcmp0(arg_change_type, "delayed-auto-refresh") == 0) {
-        launch_progress_bar(arg_change_id, state);
-    }
+static void snap_dbus_handle_change(SnapChanges *object,
+                                    const gchar *arg_change_id,
+                                    const gchar *arg_change_type,
+                                    const gchar *arg_change_kind,
+                                    GVariant *arg_metadata, DsState *state) {
+  if (g_strcmp0(arg_change_type, "delayed-auto-refresh") == 0) {
+    launch_progress_bar(arg_change_id, state);
+  }
 }
 
-void snap_dbus_cb(GDBusConnection *connection, GAsyncResult *res, DsState *state) {
-    state->snap_dbus_proxy = snap_changes_proxy_new_finish (res, NULL);
-    if (state->snap_dbus_proxy == NULL) {
-        g_warning("Failed to connect to the snap userd agent DBus interface");
-        return;
-    }
-    g_signal_connect(state->snap_dbus_proxy, "change",
-                     G_CALLBACK(snap_dbus_handle_change),
-                     state);
+void snap_dbus_cb(GDBusConnection *connection, GAsyncResult *res,
+                  DsState *state) {
+  state->snap_dbus_proxy = snap_changes_proxy_new_finish(res, NULL);
+  if (state->snap_dbus_proxy == NULL) {
+    g_warning("Failed to connect to the snap userd agent DBus interface");
+    return;
+  }
+  g_signal_connect(state->snap_dbus_proxy, "change",
+                   G_CALLBACK(snap_dbus_handle_change), state);
 }
 
 void manage_snap_dbus(GDBusConnection *connection, DsState *state) {
 
-    snap_changes_proxy_new (connection,
-                            G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
-                            "io.snapcraft.SessionAgent",
-                            "/io/snapcraft/SnapChanges",
-                            NULL,
-                            (GAsyncReadyCallback) snap_dbus_cb,
-                            state);
-
+  snap_changes_proxy_new(connection, G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                         "io.snapcraft.SessionAgent",
+                         "/io/snapcraft/SnapChanges", NULL,
+                         (GAsyncReadyCallback)snap_dbus_cb, state);
 }

--- a/src/changes.h
+++ b/src/changes.h
@@ -24,10 +24,10 @@
 #define CHANGE_CHECK_INTERVAL 333
 
 typedef struct {
-    gchar *change_id;
-    gint timeout_id;
-    DsState *state;
-    gboolean busy;
+  gchar *change_id;
+  gint timeout_id;
+  DsState *state;
+  gboolean busy;
 } SnapProgress;
 
 void manage_snap_dbus(GDBusConnection *connection, DsState *state);

--- a/src/changes.h
+++ b/src/changes.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef _CHANGES_H_
+#define _CHANGES_H_
+
+#include "ds_state.h"
+
+// check for task changes in a Change three times per second
+#define CHANGE_CHECK_INTERVAL 333
+
+typedef struct {
+    gchar *change_id;
+    gint timeout_id;
+    DsState *state;
+    gboolean busy;
+} SnapProgress;
+
+void manage_snap_dbus(GDBusConnection *connection, DsState *state);
+
+#endif // _CHANGES_H_

--- a/src/ds_state.h
+++ b/src/ds_state.h
@@ -19,6 +19,7 @@
 #define __DS_STATE_H__
 
 #include "io.snapcraft.SnapDesktopIntegration.h"
+#include "io.snapcraft.SnapChanges.h"
 #include <gtk/gtk.h>
 #include <libnotify/notify.h>
 #include <snapd-glib/snapd-glib.h>
@@ -27,6 +28,7 @@
 
 typedef struct {
   SnapDesktopIntegration *skeleton;
+  SnapChanges *snap_dbus_proxy;
 
   GtkSettings *settings;
   SnapdClient *client;

--- a/src/ds_state.h
+++ b/src/ds_state.h
@@ -18,8 +18,8 @@
 #ifndef __DS_STATE_H__
 #define __DS_STATE_H__
 
-#include "io.snapcraft.SnapDesktopIntegration.h"
 #include "io.snapcraft.SnapChanges.h"
+#include "io.snapcraft.SnapDesktopIntegration.h"
 #include <gtk/gtk.h>
 #include <libnotify/notify.h>
 #include <snapd-glib/snapd-glib.h>

--- a/src/main.c
+++ b/src/main.c
@@ -27,8 +27,8 @@
 #include <syslog.h>
 #include <unistd.h>
 
-#include "dbus.h"
 #include "changes.h"
+#include "dbus.h"
 #include "ds_state.h"
 #include "org.freedesktop.login1.Session.h"
 #include "org.freedesktop.login1.h"
@@ -393,7 +393,8 @@ static void do_startup(GObject *object, gpointer data) {
     g_clear_object(&(state->skeleton));
     g_message("Failed to export the DBus Desktop Integration API");
   }
-  manage_snap_dbus(g_application_get_dbus_connection(G_APPLICATION(state->app)), state);
+  manage_snap_dbus(g_application_get_dbus_connection(G_APPLICATION(state->app)),
+                   state);
 }
 
 static void do_activate(GObject *object, gpointer data) {

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 
 #include "dbus.h"
+#include "changes.h"
 #include "ds_state.h"
 #include "org.freedesktop.login1.Session.h"
 #include "org.freedesktop.login1.h"
@@ -382,6 +383,7 @@ static gboolean check_graphical_sessions(gpointer data) {
 static void do_startup(GObject *object, gpointer data) {
   DsState *state = (DsState *)data;
   notify_init("snapd-desktop-integration");
+  state->snap_dbus_proxy = NULL;
   state->settings = gtk_settings_get_default();
   state->client = snapd_client_new();
   state->app = GTK_APPLICATION(object);
@@ -391,6 +393,7 @@ static void do_startup(GObject *object, gpointer data) {
     g_clear_object(&(state->skeleton));
     g_message("Failed to export the DBus Desktop Integration API");
   }
+  manage_snap_dbus(g_application_get_dbus_connection(G_APPLICATION(state->app)), state);
 }
 
 static void do_activate(GObject *object, gpointer data) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,8 +5,8 @@ configure_file(output: 'config.h',
 
 snapd_desktop_integration = executable(
   'snapd-desktop-integration',
-  'main.c', 'refresh_status.c', 'dbus.c',
-  resources, gdbus_src,login_src, login_session_src,
+  'main.c', 'refresh_status.c', 'dbus.c', 'changes.c',
+  resources, gdbus_src, login_src, login_session_src, snap_changes_src,
   dependencies: [gtk_dep, snapd_glib_dep, libnotify_dep],
   install: true,
   link_args: ['-rdynamic'],

--- a/src/refresh_status.h
+++ b/src/refresh_status.h
@@ -36,7 +36,15 @@ typedef struct {
   gboolean wait_change_in_lock_file;
   gint width;
   gint height;
+
+  guint ntasks;
+  guint doneTasks;
+  guint minId;
+  gchar *summary;
+  gboolean updated;
 } RefreshState;
+
+RefreshState *ds_state_find_application(DsState *state, const char *appName);
 
 void handle_application_is_being_refreshed(gchar *appName, gchar *lockFilePath,
                                            GVariant *extraParams,


### PR DESCRIPTION
This MR adds support for using the Snapd DBus API, allowing to show the refresh progress without taxing the daemon.

The implementation is based on https://docs.google.com/document/d/1RLbTPKyPb_u47xgndPut_IC2L1WxHXUxzAx2As0Q-Vo/edit