### PR TITLE
Add back refresh dialog title.

### DIFF
--- a/data/resources/sdi-refresh-dialog.ui
+++ b/data/resources/sdi-refresh-dialog.ui
@@ -4,6 +4,7 @@
   <template class="SdiRefreshDialog" parent="GtkWindow">
     <property name="default-height">200</property>
     <property name="default-width">560</property>
+    <property name="title" translatable="yes">Snap refresh in progress</property>
     <child>
       <object class="GtkBox">
         <property name="margin-bottom">20</property>


### PR DESCRIPTION
It was accidentally removed in 57134de87eb7ebd4f8185e6ad2f3e59d157e938e