### PR TITLE
Udeng-2978: put the right icon in the top left corner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,6 @@
 # snapd-desktop-integration
 User session helpers for snapd
 
-## DBus control
-
-The program has a DBus remote control with the interface
-io.snapcraft.SnapDesktopIntegration, which offers the following methods:
-
-    ApplicationIsBeingRefreshed(identifier:s, control_file_path:s, extra_data:{s:v})
-
-        Shows a new refresh window for the program 'identifier'. If
-        'control_file_path' is empty, the window will be shown until it is
-        destroyed with ApplicationRefreshCompleted(), or by the user by
-        pressing the "Hide" button in the window. But if it points to
-        a file, the window will be destroyed when that file is deleted.
-
-        If there is already a window for that identifier, it will be moved
-        to foreground.
-
-    ApplicationRefreshCompleted(identifier:s, extra_data:{s:v})
-
-        Destroys the refresh window for the program specified in 'identifier'.
-
-    ApplicationRefreshPulsed(identifier:s, bar_text:s, extra_data:{s:v})
-
-        Sets the progress bar to "pulsed mode" for the program 'identifier', and
-        changes the text in the bar to 'bar_text'.
-
-    ApplicationRefreshPercentage(identifier:s, bar_text:s, percentage:d, extra_data:{s:v})
-
-        Sets the progress bar to "percentage mode" for the program 'identifier', and
-        changes the text in the bar to 'bar_text'. The value for the bar is the double
-        passed in 'percentage', and it must be a value between 0 and 1.
-
-### Extra data in calls
-
-All the DBus calls accept a dictionary with extra parameters, called 'extra_data'. This
-dictionary is in the format 'string:variant' for the 'key:value' data. The available keys
-and its associated data are:
-
-* title: the value must be a string variant. It will update the window's title to the
-         specified value.
-
-* message: the value must be a string variant. It will replace the message in the window
-           (which, by default, is "Please wait while...") with the specified value.
-
-* icon: the value must be a string variant containing an icon name. It will show that icon
-        to the right of the message. If the value is an empty string, the icon will be hide.
-
-* icon_image: the value must be a string variant with the path to a picture. It will show
-              that picture to the right of the message. Be careful with the picture size.
-
-### Using d-feet
-
-D-feet can be used to call the methods. To pass the 'extra_data' field, it is required to
-specify the format in the dictionary.
-
-Example for ApplicationIsBeingRefreshed:
-
-    "Firefox","",{"icon":GLib.Variant("s","firefox")}
-
-    "Telegram","",{"icon_image":GLib.Variant("s","/snap/telegram-desktop/4627/meta/gui/icon.png")}
-
 ## Code formatting
 
 Use "clang-format -i SOURCE_FILE_NAME" after any change to automatically

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,9 @@
 project('snapd-desktop-integration', 'c', version: '0.9')
 
+if get_option('gnotify')
+    add_global_arguments('-DUSE_GNOTIFY', language: 'c')
+endif
+
 gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0')
 gtk_dep = dependency('gtk4', version: '>= 4.0')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('gnotify',
+       type : 'boolean',
+       value : false,
+       description : 'Use Gio Notify instead of libnotify')

--- a/src/main.c
+++ b/src/main.c
@@ -137,7 +137,9 @@ static gboolean check_graphical_sessions(gpointer data) {
 
 static void do_startup(GObject *object, gpointer data) {
   GError *error = NULL;
-  notify_init("snapd-desktop-integration");
+#ifndef USE_GNOTIFY
+  notify_init("snapd-desktop-integration_snapd-desktop-integration");
+#endif
   client = snapd_client_new();
   refresh_monitor = sdi_refresh_monitor_new(G_APPLICATION(object));
   if (!sdi_refresh_monitor_start(refresh_monitor, &error)) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -178,8 +178,9 @@ static void show_pending_update_notification(SdiNotify *self,
                                   notification);
 }
 
-void show_simple_notification(SdiNotify *self, const gchar *title,
-                              const gchar *body, GIcon *icon, const gchar *id) {
+static void show_simple_notification(SdiNotify *self, const gchar *title,
+                                     const gchar *body, GIcon *icon,
+                                     const gchar *id) {
   g_autoptr(GNotification) notification = g_notification_new(title);
   g_notification_set_body(notification, body);
   if (icon != NULL) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -118,9 +118,10 @@ static void show_pending_update_notification(SdiNotify *self,
       notify_notification_new(title, body, icon_name);
   // don't use g_autoptr with the GVariant because it is consumed in set_hint
   GVariant *hint_icon = NULL;
-  if (icon_name != NULL)
+  if (icon_name != NULL) {
     hint_icon = g_variant_new_string(icon_name);
-  notify_notification_set_hint(notification, "image-path", hint_icon);
+    notify_notification_set_hint(notification, "image-path", hint_icon);
+  }
   notify_notification_add_action(notification, "app.close-notification",
                                  _("Close"), app_close_notification, NULL,
                                  NULL);
@@ -144,9 +145,10 @@ static void show_simple_notification(SdiNotify *self, const gchar *title,
       notify_notification_new(title, body, icon_name);
   // don't use g_autoptr with the GVariant because it is consumed in set_hint
   GVariant *hint_icon = NULL;
-  if (icon_name != NULL)
+  if (icon_name != NULL) {
     hint_icon = g_variant_new_string(icon_name);
-  notify_notification_set_hint(notification, "image-path", hint_icon);
+    notify_notification_set_hint(notification, "image-path", hint_icon);
+  }
   notify_notification_add_action(notification, "default", _("Close"),
                                  app_close_notification, NULL, NULL);
   notify_notification_show(notification, NULL);

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -65,10 +65,10 @@ static GVariant *get_snap_list(GSList *snaps) {
 }
 
 // Currently, due to the way Snapd creates the .desktop files, the notifications
-// created with GNotify don't show the application icon in the upper-left corner,
-// putting instead the "generic gears" icon. This is the reason why, by default,
-// we use libnotify. This problem is being tackled by the snapd people, so, in
-// the future, GNotify would be the prefered choice.
+// created with GNotify don't show the application icon in the upper-left
+// corner, putting instead the "generic gears" icon. This is the reason why, by
+// default, we use libnotify. This problem is being tackled by the snapd people,
+// so, in the future, GNotify would be the prefered choice.
 #ifndef USE_GNOTIFY
 
 static gchar *get_icon_name_from_gicon(GIcon *icon) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -64,6 +64,11 @@ static GVariant *get_snap_list(GSList *snaps) {
   return g_variant_ref_sink(g_variant_builder_end(builder));
 }
 
+// Currently, due to the way Snapd creates the .desktop files, the notifications
+// created with GNotify don't show the application icon in the upper-left corner,
+// putting instead the "generic gears" icon. This is the reason why, by default,
+// we use libnotify. This problem is being tackled by the snapd people, so, in
+// the future, GNotify would be the prefered choice.
 #ifndef USE_GNOTIFY
 
 static gchar *get_icon_name_from_gicon(GIcon *icon) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -119,7 +119,8 @@ static void show_pending_update_notification(SdiNotify *self,
       notify_notification_new(title, body, icon_name);
   if (icon_name != NULL) {
     // don't use g_autoptr with the GVariant because it is consumed in set_hint
-    notify_notification_set_hint(notification, "image-path", g_variant_new_string(icon_name));
+    notify_notification_set_hint(notification, "image-path",
+                                 g_variant_new_string(icon_name));
   }
   notify_notification_add_action(notification, "app.close-notification",
                                  _("Close"), app_close_notification, NULL,
@@ -144,7 +145,8 @@ static void show_simple_notification(SdiNotify *self, const gchar *title,
       notify_notification_new(title, body, icon_name);
 
   if (icon_name != NULL) {
-    notify_notification_set_hint(notification, "image-path", g_variant_new_string(icon_name));
+    notify_notification_set_hint(notification, "image-path",
+                                 g_variant_new_string(icon_name));
   }
   notify_notification_add_action(notification, "default", _("Close"),
                                  app_close_notification, NULL, NULL);
@@ -168,7 +170,7 @@ static void show_pending_update_notification(SdiNotify *self,
   g_notification_add_button_with_target(notification, _("Close"),
                                         "app.close-notification", "s",
                                         "pending-update");
-  g_autoptr (GVariant) snap_list = get_snap_list(snaps);
+  g_autoptr(GVariant) snap_list = get_snap_list(snaps);
   g_notification_add_button_with_target_value(notification, _("Ignore"),
                                               "app.ignore-updates", snap_list);
   g_application_send_notification(self->application, "pending-update",

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -81,6 +81,7 @@ static gchar *get_icon_name_from_gicon(GIcon *icon) {
 
   if (G_IS_FILE_ICON(icon)) {
     GFileIcon *file_icon = G_FILE_ICON(icon);
+    // the value returned by g_file_icon_get_file() is owned by the instance
     return g_file_get_path(g_file_icon_get_file(file_icon));
   }
   return NULL;
@@ -116,10 +117,9 @@ static void show_pending_update_notification(SdiNotify *self,
   // Don't use g_autoptr because it must survive for the actions
   NotifyNotification *notification =
       notify_notification_new(title, body, icon_name);
-  // don't use g_autoptr with the GVariant because it is consumed in set_hint
-  GVariant *hint_icon = NULL;
   if (icon_name != NULL) {
-    hint_icon = g_variant_new_string(icon_name);
+    // don't use g_autoptr with the GVariant because it is consumed in set_hint
+    GVariant *hint_icon = g_variant_new_string(icon_name);
     notify_notification_set_hint(notification, "image-path", hint_icon);
   }
   notify_notification_add_action(notification, "app.close-notification",
@@ -143,10 +143,10 @@ static void show_simple_notification(SdiNotify *self, const gchar *title,
   // Don't use g_autoptr because it must survive for the actions
   NotifyNotification *notification =
       notify_notification_new(title, body, icon_name);
-  // don't use g_autoptr with the GVariant because it is consumed in set_hint
-  GVariant *hint_icon = NULL;
+
   if (icon_name != NULL) {
-    hint_icon = g_variant_new_string(icon_name);
+    // don't use g_autoptr with the GVariant because it is consumed in set_hint
+    GVariant *hint_icon = g_variant_new_string(icon_name);
     notify_notification_set_hint(notification, "image-path", hint_icon);
   }
   notify_notification_add_action(notification, "default", _("Close"),

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -21,6 +21,7 @@
 
 #include <gio/gdesktopappinfo.h>
 #include <glib/gi18n.h>
+#include <libnotify/notify.h>
 
 #include "sdi-helpers.h"
 #include "sdi-notify.h"
@@ -35,11 +36,123 @@ struct _SdiNotify {
 
 G_DEFINE_TYPE(SdiNotify, sdi_notify, G_TYPE_OBJECT)
 
+static void sdi_notify_action_ignore(GActionGroup *action_group,
+                                     GVariant *app_list, SdiNotify *self) {
+  gsize len;
+  g_autofree gchar **apps = (gchar **)g_variant_get_strv(app_list, &len);
+
+  g_return_if_fail(apps != NULL);
+  for (gsize i = 0; i < len; i++)
+    g_signal_emit_by_name(self, "ignore-snap-event", apps[i]);
+}
+
 static GTimeSpan get_remaining_time(SnapdSnap *snap) {
   g_autoptr(GDateTime) proceed_time = snapd_snap_get_proceed_time(snap);
   g_autoptr(GDateTime) now = g_date_time_new_now_local();
   return g_date_time_difference(proceed_time, now);
 }
+
+static GVariant *get_snap_list(GSList *snaps) {
+  if (snaps == NULL)
+    return NULL;
+  g_autoptr(GVariantBuilder) builder =
+      g_variant_builder_new(G_VARIANT_TYPE("as"));
+  for (; snaps != NULL; snaps = snaps->next) {
+    SnapdSnap *snap = (SnapdSnap *)snaps->data;
+    g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
+  }
+  return g_variant_builder_end(builder);
+}
+
+#ifndef USE_GNOTIFY
+
+static gchar *get_icon_name_from_gicon(GIcon *icon) {
+  if (icon == NULL) {
+    return NULL;
+  }
+
+  if (G_IS_THEMED_ICON(icon)) {
+    GThemedIcon *themed_icon = G_THEMED_ICON(icon);
+    const gchar *const *names = g_themed_icon_get_names(themed_icon);
+    if (names == NULL)
+      return NULL;
+    return g_strdup(names[0]);
+  }
+
+  if (G_IS_FILE_ICON(icon)) {
+    GFileIcon *file_icon = G_FILE_ICON(icon);
+    return g_file_get_path(g_file_icon_get_file(file_icon));
+  }
+  return NULL;
+}
+
+typedef struct {
+  SdiNotify *self;
+  GVariant *snaps;
+} IgnoreNotifyData;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(NotifyNotification, g_object_unref)
+
+static void app_close_notification(NotifyNotification *notification,
+                                   char *action, gpointer user_data) {
+  g_object_unref(notification);
+}
+
+static void app_ignore_snaps_notification(NotifyNotification *notification,
+                                          char *action, gpointer user_data) {
+  IgnoreNotifyData *data = user_data;
+  sdi_notify_action_ignore(NULL, data->snaps, data->self);
+  g_variant_unref(data->snaps);
+  g_free(user_data);
+
+  g_object_unref(notification);
+}
+
+static void show_pending_update_notification(SdiNotify *self,
+                                             const gchar *title,
+                                             const gchar *body, GIcon *icon,
+                                             GSList *snaps) {
+  g_autofree gchar *icon_name = get_icon_name_from_gicon(icon);
+  // Don't use g_autoptr because it must survive for the actions
+  NotifyNotification *notification =
+      notify_notification_new(title, body, icon_name);
+  // don't use g_autoptr with the GVariant because it is consumed in set_hint
+  GVariant *hint_icon = NULL;
+  if (icon_name != NULL)
+    hint_icon = g_variant_new_string(icon_name);
+  notify_notification_set_hint(notification, "image-path", hint_icon);
+  notify_notification_add_action(notification, "app.close-notification",
+                                 _("Close"), app_close_notification, NULL,
+                                 NULL);
+  notify_notification_add_action(notification, "default", _("Close"),
+                                 app_close_notification, NULL, NULL);
+  IgnoreNotifyData *data = g_malloc(sizeof(IgnoreNotifyData));
+  data->self = self;
+  data->snaps = get_snap_list(snaps);
+  notify_notification_add_action(notification, "app.ignore-notification",
+                                 _("Ignore"), app_ignore_snaps_notification,
+                                 data, NULL);
+  notify_notification_show(notification, NULL);
+}
+
+static void show_simple_notification(SdiNotify *self, const gchar *title,
+                                     const gchar *body, GIcon *icon,
+                                     const gchar *id) {
+  g_autofree gchar *icon_name = get_icon_name_from_gicon(icon);
+  // Don't use g_autoptr because it must survive for the actions
+  NotifyNotification *notification =
+      notify_notification_new(title, body, icon_name);
+  // don't use g_autoptr with the GVariant because it is consumed in set_hint
+  GVariant *hint_icon = NULL;
+  if (icon_name != NULL)
+    hint_icon = g_variant_new_string(icon_name);
+  notify_notification_set_hint(notification, "image-path", hint_icon);
+  notify_notification_add_action(notification, "default", _("Close"),
+                                 app_close_notification, NULL, NULL);
+  notify_notification_show(notification, NULL);
+}
+
+#else
 
 static void show_pending_update_notification(SdiNotify *self,
                                              const gchar *title,
@@ -53,24 +166,18 @@ static void show_pending_update_notification(SdiNotify *self,
   }
   g_notification_set_default_action_and_target(
       notification, "app.close-notification", "s", "pending-update");
-  g_notification_add_button_with_target(
-      notification, "Close", "app.close-notification", "s", "pending-update");
-  g_autoptr(GVariantBuilder) builder =
-      g_variant_builder_new(G_VARIANT_TYPE("as"));
-  for (; snaps != NULL; snaps = snaps->next) {
-    SnapdSnap *snap = (SnapdSnap *)snaps->data;
-    g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
-  }
-  GVariant *values = g_variant_builder_end(builder);
-  g_notification_add_button_with_target_value(notification, "Ignore",
+  g_notification_add_button_with_target(notification, _("Close"),
+                                        "app.close-notification", "s",
+                                        "pending-update");
+  GVariant *values = get_snap_list(snaps);
+  g_notification_add_button_with_target_value(notification, _("Ignore"),
                                               "app.ignore-updates", values);
   g_application_send_notification(self->application, "pending-update",
                                   notification);
 }
 
-static void show_simple_notification(SdiNotify *self, const gchar *title,
-                                     const gchar *body, GIcon *icon,
-                                     const gchar *id) {
+void show_simple_notification(SdiNotify *self, const gchar *title,
+                              const gchar *body, GIcon *icon, const gchar *id) {
   g_autoptr(GNotification) notification = g_notification_new(title);
   g_notification_set_body(notification, body);
   if (icon != NULL) {
@@ -78,6 +185,7 @@ static void show_simple_notification(SdiNotify *self, const gchar *title,
   }
   g_application_send_notification(self->application, id, notification);
 }
+#endif
 
 void sdi_notify_pending_refresh_one(SdiNotify *self, SnapdSnap *snap) {
   g_return_if_fail(SDI_IS_NOTIFY(self));
@@ -178,16 +286,6 @@ void sdi_notify_refresh_complete(SdiNotify *self, SnapdSnap *snap,
 GApplication *sdi_notify_get_application(SdiNotify *self) {
   g_return_val_if_fail(SDI_IS_NOTIFY(self), NULL);
   return self->application;
-}
-
-static void sdi_notify_action_ignore(GActionGroup *action_group,
-                                     GVariant *app_list, SdiNotify *self) {
-  gsize len;
-  g_autofree gchar **apps = (gchar **)g_variant_get_strv(app_list, &len);
-
-  g_return_if_fail(apps != NULL);
-  for (gsize i = 0; i < len; i++)
-    g_signal_emit_by_name(self, "ignore-snap-event", apps[i]);
 }
 
 static void set_actions(SdiNotify *self) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -61,7 +61,7 @@ static GVariant *get_snap_list(GSList *snaps) {
     SnapdSnap *snap = (SnapdSnap *)snaps->data;
     g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
   }
-  return g_variant_builder_end(builder);
+  return g_variant_ref_sink(g_variant_builder_end(builder));
 }
 
 #ifndef USE_GNOTIFY
@@ -119,8 +119,7 @@ static void show_pending_update_notification(SdiNotify *self,
       notify_notification_new(title, body, icon_name);
   if (icon_name != NULL) {
     // don't use g_autoptr with the GVariant because it is consumed in set_hint
-    GVariant *hint_icon = g_variant_new_string(icon_name);
-    notify_notification_set_hint(notification, "image-path", hint_icon);
+    notify_notification_set_hint(notification, "image-path", g_variant_new_string(icon_name));
   }
   notify_notification_add_action(notification, "app.close-notification",
                                  _("Close"), app_close_notification, NULL,
@@ -145,9 +144,7 @@ static void show_simple_notification(SdiNotify *self, const gchar *title,
       notify_notification_new(title, body, icon_name);
 
   if (icon_name != NULL) {
-    // don't use g_autoptr with the GVariant because it is consumed in set_hint
-    GVariant *hint_icon = g_variant_new_string(icon_name);
-    notify_notification_set_hint(notification, "image-path", hint_icon);
+    notify_notification_set_hint(notification, "image-path", g_variant_new_string(icon_name));
   }
   notify_notification_add_action(notification, "default", _("Close"),
                                  app_close_notification, NULL, NULL);
@@ -171,9 +168,9 @@ static void show_pending_update_notification(SdiNotify *self,
   g_notification_add_button_with_target(notification, _("Close"),
                                         "app.close-notification", "s",
                                         "pending-update");
-  GVariant *values = get_snap_list(snaps);
+  g_autoptr (GVariant) snap_list = get_snap_list(snaps);
   g_notification_add_button_with_target_value(notification, _("Ignore"),
-                                              "app.ignore-updates", values);
+                                              "app.ignore-updates", snap_list);
   g_application_send_notification(self->application, "pending-update",
                                   notification);
 }


### PR DESCRIPTION
Due to the fact that snap doesn't set a .desktop file for the snaps with the original name, but builds one with snap-name_app-name.desktop, the desktop identification usually fails. This makes GNotify to not be able to identify the .desktop file and set the right icon in the top-left corner of the notifications it sends.

![imagen](https://github.com/snapcore/snapd-desktop-integration/assets/105285003/cc42d391-6aec-4319-b22a-04fda2a77e94)

This patch migrates the notification code to libnotify, which allows to bypass this problem. But the original code is kept  inside an #ifdef to allow to revert to it in the future, when this problem is fixed in snapd.