### PR TITLE
Add desktop-launch in the plug list

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,7 @@ apps:
       - login-session-observe
       - snap
       - snap-refresh-observe
+      - desktop-launch
 
 slots:
   snapd-desktop-integration:


### PR DESCRIPTION
The *desktop-launch* interface is required to be able to read the application icon and the visible name. The automatic connection is already requested at https://forum.snapcraft.io/t/request-for-desktop-launch-interface-for-snapd-desktop-integration/40634