### PR TITLE
Launch the store from refresh notification

### DIFF
--- a/data/io.snapcraft.PrivilegedDesktopLauncher.dbus.xml
+++ b/data/io.snapcraft.PrivilegedDesktopLauncher.dbus.xml
@@ -1,0 +1,21 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+ <interface name="org.freedesktop.DBus.Introspectable">
+  <method name="Introspect">
+   <arg name="xml_data" type="s" direction="out"/>
+  </method>
+ </interface>
+ <interface name="org.freedesktop.DBus.Peer">
+  <method name="GetMachineId">
+   <arg name="machine_uuid" direction="out" type="s"/>
+  </method>
+  <method name="Ping">
+  </method>
+ </interface>
+ <interface name="io.snapcraft.PrivilegedDesktopLauncher">
+  <method name="OpenDesktopEntry">
+   <arg type="s" name="desktop_file_id"/>
+  </method>
+ </interface>
+</node>

--- a/data/meson.build
+++ b/data/meson.build
@@ -17,6 +17,11 @@ unity_launcher_src = gnome.gdbus_codegen('com.canonical.Unity.LauncherEntry',
   sources: 'com.canonical.Unity.LauncherEntry.dbus.xml',
   interface_prefix : 'com.canonical.unity.launcherentry',
   namespace: 'Unity'
+
+desktop_launcher_src = gnome.gdbus_codegen('io.snapcraft.PrivilegedDesktopLauncher',
+  sources: 'io.snapcraft.PrivilegedDesktopLauncher.dbus.xml',
+  interface_prefix : 'io.snapcraft.PrivilegedDesktopLauncher',
+  namespace: 'PrivilegedDesktopLauncher'
 )
 
 install_data('io.snapcraft.SnapDesktopIntegration.desktop', install_dir: 'share/applications')

--- a/data/meson.build
+++ b/data/meson.build
@@ -17,6 +17,7 @@ unity_launcher_src = gnome.gdbus_codegen('com.canonical.Unity.LauncherEntry',
   sources: 'com.canonical.Unity.LauncherEntry.dbus.xml',
   interface_prefix : 'com.canonical.unity.launcherentry',
   namespace: 'Unity'
+)
 
 desktop_launcher_src = gnome.gdbus_codegen('io.snapcraft.PrivilegedDesktopLauncher',
   sources: 'io.snapcraft.PrivilegedDesktopLauncher.dbus.xml',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -36,6 +36,7 @@ apps:
       - snap
       - snap-refresh-observe
       - unity7
+      - desktop-launch
 
 slots:
   snapd-desktop-integration:

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,7 @@ snapd_desktop_integration = executable(
   'sdi-refresh-monitor.c',
   'sdi-theme-monitor.c',
   'sdi-helpers.c',
-  resources, login_src, login_session_src, unity_launcher_src,
+  resources, login_src, login_session_src, unity_launcher_src, desktop_launcher_src,
   dependencies: [gtk_dep, snapd_glib_dep, libnotify_dep],
   install: true,
   link_args: ['-rdynamic'],

--- a/src/sdi-helpers.c
+++ b/src/sdi-helpers.c
@@ -16,6 +16,7 @@
  */
 
 #include "sdi-helpers.h"
+#include "io.snapcraft.PrivilegedDesktopLauncher.h"
 
 GAppInfo *sdi_get_desktop_file_from_snap(SnapdSnap *snap) {
   GPtrArray *apps = snapd_snap_get_apps(snap);
@@ -78,4 +79,15 @@ GPtrArray *sdi_get_desktop_filenames_for_snap(const gchar *snap_name) {
     g_ptr_array_add(desktop_files, g_strdup(filename));
   }
   return desktop_files;
+}
+
+void sdi_launch_desktop(GApplication *app, const gchar *desktop_file) {
+  g_autoptr(PrivilegedDesktopLauncher) launcher = NULL;
+
+  launcher = privileged_desktop_launcher__proxy_new_sync(
+      g_application_get_dbus_connection(app), G_DBUS_PROXY_FLAGS_NONE,
+      "io.snapcraft.Launcher", "/io/snapcraft/PrivilegedDesktopLauncher", NULL,
+      NULL);
+  privileged_desktop_launcher__call_open_desktop_entry_sync(
+      launcher, desktop_file, NULL, NULL);
 }

--- a/src/sdi-helpers.h
+++ b/src/sdi-helpers.h
@@ -22,3 +22,4 @@
 
 GAppInfo *sdi_get_desktop_file_from_snap(SnapdSnap *snap);
 GPtrArray *sdi_get_desktop_filenames_for_snap(const gchar *snap_name);
+void sdi_launch_desktop(GApplication *app, const gchar *desktop_file);

--- a/src/sdi-helpers.h
+++ b/src/sdi-helpers.h
@@ -22,4 +22,4 @@
 
 GAppInfo *sdi_get_desktop_file_from_snap(SnapdSnap *snap);
 GPtrArray *sdi_get_desktop_filenames_for_snap(const gchar *snap_name);
-void sdi_launch_desktop(GApplication *app, const gchar *desktop_file);
+gboolean sdi_launch_desktop(GApplication *app, const gchar *desktop_file);

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -18,8 +18,7 @@
 #define SECONDS_IN_A_DAY 86400
 #define SECONDS_IN_AN_HOUR 3600
 #define SECONDS_IN_A_MINUTE 60
-#define SNAP_STORE                                                             \
-  "/var/lib/snapd/desktop/applications/snap-store_snap-store.desktop"
+#define SNAP_STORE "snap-store_snap-store.desktop"
 
 #include <gio/gdesktopappinfo.h>
 #include <glib/gi18n.h>
@@ -319,7 +318,7 @@ GApplication *sdi_notify_get_application(SdiNotify *self) {
 static void sdi_notify_action_show_updates(GActionGroup *action_group,
                                            GVariant *str_data,
                                            SdiNotify *self) {
-  sdi_launch_desktop(self->application, "snap-store_snap-store.desktop");
+  sdi_launch_desktop(self->application, SNAP_STORE);
 }
 
 static void set_actions(SdiNotify *self) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -38,20 +38,22 @@ struct _SdiNotify {
 
 G_DEFINE_TYPE(SdiNotify, sdi_notify, G_TYPE_OBJECT)
 
-static void sdi_notify_action_ignore(GActionGroup *action_group,
-                                     GVariant *app_list, SdiNotify *self) {
-  gsize len;
-  g_autofree gchar **apps = (gchar **)g_variant_get_strv(app_list, &len);
-
-  g_return_if_fail(apps != NULL);
-  for (gsize i = 0; i < len; i++)
-    g_signal_emit_by_name(self, "ignore-snap-event", apps[i]);
-}
-
 static GTimeSpan get_remaining_time(SnapdSnap *snap) {
   g_autoptr(GDateTime) proceed_time = snapd_snap_get_proceed_time(snap);
   g_autoptr(GDateTime) now = g_date_time_new_now_local();
   return g_date_time_difference(proceed_time, now);
+}
+
+static void show_updates(SdiNotify *self) {
+  if (!sdi_launch_desktop(self->application, SNAP_STORE_UPDATES)) {
+    sdi_launch_desktop(self->application, SNAP_STORE);
+  }
+}
+
+static void sdi_notify_action_show_updates(GActionGroup *action_group,
+                                           GVariant *str_data,
+                                           SdiNotify *self) {
+  show_updates(self);
 }
 
 static GVariant *get_snap_list(GSList *snaps) {
@@ -64,6 +66,16 @@ static GVariant *get_snap_list(GSList *snaps) {
     g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
   }
   return g_variant_ref_sink(g_variant_builder_end(builder));
+}
+
+static void sdi_notify_action_ignore(GActionGroup *action_group,
+                                     GVariant *app_list, SdiNotify *self) {
+  gsize len;
+  g_autofree gchar **apps = (gchar **)g_variant_get_strv(app_list, &len);
+
+  g_return_if_fail(apps != NULL);
+  for (gsize i = 0; i < len; i++)
+    g_signal_emit_by_name(self, "ignore-snap-event", apps[i]);
 }
 
 // Currently, due to the way Snapd creates the .desktop files, the notifications
@@ -117,8 +129,43 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(IgnoreNotifyData, ignore_notify_data_free)
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(NotifyNotification, g_object_unref)
 
+typedef struct {
+  SdiNotify *self;
+  gchar *desktop;
+} LaunchUpdatedApp;
+
+LaunchUpdatedApp *launch_updated_app_new(SdiNotify *self,
+                                         const gchar *desktop) {
+  LaunchUpdatedApp *data = g_malloc0(sizeof(LaunchUpdatedApp));
+  data->self = g_object_ref(self);
+  data->desktop = g_strdup(desktop);
+  return data;
+}
+
+void launch_updated_app_free(void *user_data) {
+  LaunchUpdatedApp *data = (LaunchUpdatedApp *)user_data;
+  g_object_unref(data->self);
+  g_free(data->desktop);
+  g_free(data);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(LaunchUpdatedApp, launch_updated_app_free)
+
 static void app_close_notification(NotifyNotification *notification,
                                    char *action, gpointer user_data) {
+  g_object_unref(notification);
+}
+
+static void app_launch_updated(NotifyNotification *notification, char *action,
+                               gpointer user_data) {
+  LaunchUpdatedApp *data = (LaunchUpdatedApp *)user_data;
+  sdi_launch_desktop(data->self->application, (const gchar *)data->desktop);
+  g_object_unref(notification);
+}
+
+static void app_show_updates(NotifyNotification *notification, char *action,
+                             gpointer user_data) {
+  show_updates((SdiNotify *)user_data);
   g_object_unref(notification);
 }
 
@@ -126,24 +173,6 @@ static void app_ignore_snaps_notification(NotifyNotification *notification,
                                           char *action,
                                           IgnoreNotifyData *data) {
   sdi_notify_action_ignore(NULL, data->snaps, data->self);
-  g_object_unref(notification);
-}
-
-static void show_updates(SdiNotify *self) {
-  if (!sdi_launch_desktop(self->application, SNAP_STORE_UPDATES)) {
-    sdi_launch_desktop(self->application, SNAP_STORE);
-  }
-}
-
-static void sdi_notify_action_show_updates(GActionGroup *action_group,
-                                           GVariant *str_data,
-                                           SdiNotify *self) {
-  show_updates(self);
-}
-
-static void app_show_updates(NotifyNotification *notification, char *action,
-                             gpointer user_data) {
-  show_updates((SdiNotify *)user_data);
   g_object_unref(notification);
 }
 
@@ -174,9 +203,10 @@ static void show_pending_update_notification(SdiNotify *self,
   notify_notification_show(notification, NULL);
 }
 
-static void show_simple_notification(SdiNotify *self, const gchar *title,
-                                     const gchar *body, GIcon *icon,
-                                     const gchar *id) {
+static void update_complete_notification(SdiNotify *self, const gchar *title,
+                                         const gchar *body, GIcon *icon,
+                                         const gchar *id,
+                                         const gchar *desktop) {
   g_autofree gchar *icon_name = get_icon_name_from_gicon(icon);
   // Don't use g_autoptr because it must survive for the actions
   NotifyNotification *notification =
@@ -187,8 +217,15 @@ static void show_simple_notification(SdiNotify *self, const gchar *title,
                                  g_variant_new_string(icon_name));
   }
 
-  notify_notification_add_action(notification, "default", _("Close"),
-                                 app_close_notification, NULL, NULL);
+  if (desktop == NULL) {
+    notify_notification_add_action(notification, "default", _("Close"),
+                                   app_close_notification, NULL, NULL);
+  } else {
+    LaunchUpdatedApp *data = launch_updated_app_new(self, desktop);
+    notify_notification_add_action(notification, "default", _("Close"),
+                                   app_launch_updated, data,
+                                   launch_updated_app_free);
+  }
   notify_notification_show(notification, NULL);
 }
 
@@ -222,13 +259,18 @@ static void show_pending_update_notification(SdiNotify *self,
                                   notification);
 }
 
-static void show_simple_notification(SdiNotify *self, const gchar *title,
-                                     const gchar *body, GIcon *icon,
-                                     const gchar *id) {
+static void update_complete_notification(SdiNotify *self, const gchar *title,
+                                         const gchar *body, GIcon *icon,
+                                         const gchar *id,
+                                         const gchar *desktop) {
   g_autoptr(GNotification) notification = g_notification_new(title);
   g_notification_set_body(notification, body);
   if (icon != NULL) {
     g_notification_set_icon(notification, g_object_ref(icon));
+  }
+  if (desktop != NULL) {
+    g_notification_set_default_action_and_target(
+        notification, "app.launch-refreshed-app", "s", desktop);
   }
   g_application_send_notification(self->application, id, notification);
 }
@@ -311,12 +353,14 @@ void sdi_notify_refresh_complete(SdiNotify *self, SnapdSnap *snap,
   GIcon *icon = NULL;
   g_autoptr(GAppInfo) app_info = NULL;
   const gchar *name = NULL;
+  const gchar *desktop = NULL;
 
   if (snap != NULL) {
     app_info = sdi_get_desktop_file_from_snap(snap);
     if (app_info != NULL) {
       name = g_app_info_get_display_name(app_info);
       icon = g_app_info_get_icon(app_info);
+      desktop = g_desktop_app_info_get_filename(G_DESKTOP_APP_INFO(app_info));
     }
     if (name == NULL)
       name = snapd_snap_get_name(snap);
@@ -326,8 +370,8 @@ void sdi_notify_refresh_complete(SdiNotify *self, SnapdSnap *snap,
 
   g_autofree gchar *title = g_strdup_printf(_("%s was updated"), name);
 
-  show_simple_notification(self, title, _("Ready to launch"), icon,
-                           "update-complete");
+  update_complete_notification(self, title, _("Ready to launch"), icon,
+                               "update-complete", desktop);
 }
 
 GApplication *sdi_notify_get_application(SdiNotify *self) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -18,6 +18,8 @@
 #define SECONDS_IN_A_DAY 86400
 #define SECONDS_IN_AN_HOUR 3600
 #define SECONDS_IN_A_MINUTE 60
+#define SNAP_STORE                                                             \
+  "/var/lib/snapd/desktop/applications/snap-store_snap-store.desktop"
 
 #include <gio/gdesktopappinfo.h>
 #include <glib/gi18n.h>
@@ -185,12 +187,18 @@ static void show_pending_update_notification(SdiNotify *self,
   }
   g_notification_set_default_action_and_target(
       notification, "app.close-notification", "s", "pending-update");
-  g_notification_add_button_with_target(notification, _("Close"),
-                                        "app.close-notification", "s",
+  g_notification_add_button_with_target(notification, _("Show updates"),
+                                        "app.show-updates", "s",
                                         "pending-update");
-  g_autoptr(GVariant) snap_list = get_snap_list(snaps);
-  g_notification_add_button_with_target_value(notification, _("Ignore"),
-                                              "app.ignore-updates", snap_list);
+  g_autoptr(GVariantBuilder) builder =
+      g_variant_builder_new(G_VARIANT_TYPE("as"));
+  for (; snaps != NULL; snaps = snaps->next) {
+    SnapdSnap *snap = (SnapdSnap *)snaps->data;
+    g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
+  }
+  GVariant *values = g_variant_builder_end(builder);
+  g_notification_add_button_with_target_value(
+      notification, _("Don't remind me again"), "app.ignore-updates", values);
   g_application_send_notification(self->application, "pending-update",
                                   notification);
 }
@@ -308,6 +316,12 @@ GApplication *sdi_notify_get_application(SdiNotify *self) {
   return self->application;
 }
 
+static void sdi_notify_action_show_updates(GActionGroup *action_group,
+                                           GVariant *str_data,
+                                           SdiNotify *self) {
+  sdi_launch_desktop(self->application, "snap-store_snap-store.desktop");
+}
+
 static void set_actions(SdiNotify *self) {
   g_autoptr(GVariantType) type_ignore = g_variant_type_new("as");
   g_autoptr(GSimpleAction) action_ignore =
@@ -317,10 +331,17 @@ static void set_actions(SdiNotify *self) {
   g_autoptr(GVariantType) type_close = g_variant_type_new("s");
   g_autoptr(GSimpleAction) action_close =
       g_simple_action_new("close-notification", type_close);
+  g_autoptr(GVariantType) type_updates = g_variant_type_new("s");
   g_action_map_add_action(G_ACTION_MAP(self->application),
                           G_ACTION(action_close));
+  g_autoptr(GSimpleAction) action_show_updates =
+      g_simple_action_new("show-updates", type_updates);
+  g_action_map_add_action(G_ACTION_MAP(self->application),
+                          G_ACTION(action_show_updates));
   g_signal_connect(G_OBJECT(action_ignore), "activate",
                    (GCallback)sdi_notify_action_ignore, self);
+  g_signal_connect(G_OBJECT(action_show_updates), "activate",
+                   (GCallback)sdi_notify_action_show_updates, self);
 }
 
 static void sdi_notify_set_property(GObject *object, guint prop_id,

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -19,6 +19,7 @@
 #define SECONDS_IN_AN_HOUR 3600
 #define SECONDS_IN_A_MINUTE 60
 #define SNAP_STORE "snap-store_snap-store.desktop"
+#define SNAP_STORE_UPDATES "snap-store_show-updates.desktop"
 
 #include <gio/gdesktopappinfo.h>
 #include <glib/gi18n.h>
@@ -318,7 +319,9 @@ GApplication *sdi_notify_get_application(SdiNotify *self) {
 static void sdi_notify_action_show_updates(GActionGroup *action_group,
                                            GVariant *str_data,
                                            SdiNotify *self) {
-  sdi_launch_desktop(self->application, SNAP_STORE);
+  if (!sdi_launch_desktop(self->application, SNAP_STORE_UPDATES)) {
+    sdi_launch_desktop(self->application, SNAP_STORE);
+  }
 }
 
 static void set_actions(SdiNotify *self) {

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -356,6 +356,8 @@ static void update_dock_bar(gpointer key, gpointer value, gpointer data) {
                         g_variant_new_double(progress));
   g_variant_builder_add(builder, "{sv}", "progress-visible",
                         g_variant_new_boolean(!task_data->done));
+  g_variant_builder_add(builder, "{sv}", "updating",
+                        g_variant_new_boolean(!task_data->done));
 
   g_autoptr(GVariant) values =
       g_object_ref_sink(g_variant_builder_end(builder));


### PR DESCRIPTION
The UX team asked for allowing to launch the store directly from a pending refresh notification, to allow the user to see what snaps are pending. Also recommended a change in the text of the other button in the notifications.

![Captura desde 2024-07-05 19-23-17](https://github.com/snapcore/snapd-desktop-integration/assets/105285003/6711e3cc-b247-400b-9891-78c5f1963d62)

EDIT: now it also launches the updated snap when clicking in the "Snap is updated" notification.
