### PR TITLE
Fix odd progress bar

### DIFF
--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -339,6 +339,9 @@ static void update_dock_bar(gpointer key, gpointer value, gpointer data) {
   SnapProgressTaskData *task_data = value;
   SdiRefreshMonitor *self = data;
 
+  if (task_data->total_tasks == 0) {
+    return;
+  }
   gdouble progress =
       ((gdouble)task_data->done_tasks) / ((gdouble)task_data->total_tasks);
   if ((progress == task_data->old_progress) && !task_data->done) {

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -344,11 +344,11 @@ static void update_dock_bar(gpointer key, gpointer value, gpointer data) {
   }
   gdouble progress =
       ((gdouble)task_data->done_tasks) / ((gdouble)task_data->total_tasks);
+  task_data->done_tasks = 0;
+  task_data->total_tasks = 0;
   if ((progress == task_data->old_progress) && !task_data->done) {
     return;
   }
-  task_data->done_tasks = 0;
-  task_data->total_tasks = 0;
   task_data->old_progress = progress;
   if (task_data->desktop_files->len == 0) {
     return;


### PR DESCRIPTION
Sometimes, an incorrect value with the number of tasks is sent, and the progress bar shows an odd appearance. This patch fixes it.