### PR TITLE
Fix cancelled refreshes

### DIFF
--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -451,7 +451,7 @@ static void manage_change_update(SnapdClient *source, GAsyncResult *res,
   gboolean cancelled = cancelled_change_status(change_status);
   gboolean valid_do = valid_working_change_status(change_status);
   if (!(valid_do || cancelled)) {
-    g_print("Unknown state %s\n", change_status);
+    g_debug("Unknown change status %s\n", change_status);
     return;
   }
 

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -451,7 +451,7 @@ static void manage_change_update(SnapdClient *source, GAsyncResult *res,
   gboolean cancelled = cancelled_change_status(change_status);
   gboolean valid_do = valid_working_change_status(change_status);
   if (!(valid_do || cancelled)) {
-    g_debug("Unknown change status %s\n", change_status);
+    g_debug("Unknown change status %s", change_status);
     return;
   }
 


### PR DESCRIPTION
When a refresh was cancelled (for example, because the snap was launched before it has completed the refresh), the snap is reverted, but the current code fails to detect correctly this, and snapd-desktop-integration could be left in an invalid state, asking for already completed changes over and over again.

This patch fixes this bug.