### PR TITLE
Changed the notify_init application name

### DIFF
--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -572,7 +572,7 @@ static void sdi_notify_dispose(GObject *object) {
 
 void sdi_notify_init(SdiNotify *self) {
 #ifndef USE_GNOTIFY
-  notify_init("snapd-desktop-integration-test_snapd-desktop-integration-test");
+  notify_init("Snapd Desktop Integration");
 #endif
 }
 


### PR DESCRIPTION
The notify_init call had an incorrect value, which showed an odd title in the notifications.

This patch fixes this.