### PR TITLE
Don't run TIOBE tests in forks

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   unitary-tests:
+    if: github.repository_owner == 'canonical'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Only the main repo has access to several secrets required to run the TIOBE tests, so we must avoid running them in the forks.