### PR TITLE
Fix TIC upload

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -50,11 +50,8 @@ jobs:
           wlheadless-run -c weston -- ./_build/tests/test-snapd-desktop-integration
       - name: Test notices monitor
         run: |
-          ./_build/tests/test-sdi-notices-monitor
-          ./_build/tests/test-sdi-progress-dock
-          ./_build/tests/test-sdi-notify
-          ./_build/tests/test-refresh-monitor
-          wlheadless-run -c weston -- ./_build/tests/test-sdi-progress-window
+          # can't use XVFB because gtk_settings uses Xsettings by default, but we need to use keyfile backend
+          wlheadless-run -c weston -- meson test -v -C _build --print-errorlogs -t 3
       - name: Coverage
         run: |
           mkdir -p coverage

--- a/.github/workflows/unitary-test.yaml
+++ b/.github/workflows/unitary-test.yaml
@@ -45,3 +45,7 @@ jobs:
         run: |
           # can't use XVFB because gtk_settings uses Xsettings by default, but we need to use keyfile backend
           wlheadless-run -c weston -- meson test -v -C _build --print-errorlogs -t 3
+      - name: Coverage
+        run: |
+          mkdir -p coverage
+          gcovr _build --cobertura coverage/cobertura.xml


### PR DESCRIPTION
The TICS CI fails because one of the tests isn't being run. This PR adds a check for the coverage in the normal tests, and also uses the same command for the TICS CI.