### PR TITLE
Fix g_atomic_ref_count_dec assertion error

### DIFF
--- a/src/user-session-helper/sdi-user-session-helper.c
+++ b/src/user-session-helper/sdi-user-session-helper.c
@@ -53,7 +53,7 @@ static gboolean sdi_session_is_desktop(const gchar *object_path) {
   g_autoptr(OrgFreedesktopLogin1Session) session = NULL;
   guint32 user;
   // these values belongs to the session proxy, so they must not be freed
-  g_autoptr(GVariant) user_data = NULL;
+  GVariant *user_data = NULL;
   const gchar *session_type = NULL;
 
   session = org_freedesktop_login1_session_proxy_new_for_bus_sync(


### PR DESCRIPTION
When `user-session-helper` is run, an error is shown in the journal:

    g_atomic_ref_count_dec: assertion 'old_value > 0' failed

This is because a GVariant is being defined with g_autoptr and freed, when, in reality, it belongs to a container object, thus being released twice.

This patch fixes it.